### PR TITLE
fix(honesty): wire real Nexus validator stages for parity with paper-trade

### DIFF
--- a/.github/module_budgets.json
+++ b/.github/module_budgets.json
@@ -12,7 +12,7 @@
   "backtest_simulator/honesty/__init__.py": 40,
   "backtest_simulator/honesty/atr.py": 150,
   "backtest_simulator/honesty/book_gap.py": 100,
-  "backtest_simulator/honesty/capital.py": 460,
+  "backtest_simulator/honesty/capital.py": 540,
   "backtest_simulator/honesty/conservation.py": 200,
   "backtest_simulator/honesty/risk.py": 80,
   "backtest_simulator/honesty/cpcv.py": 100,

--- a/.github/module_budgets.json
+++ b/.github/module_budgets.json
@@ -2,7 +2,7 @@
   "backtest_simulator/__init__.py": 50,
   "backtest_simulator/_limen_cache.py": 100,
   "backtest_simulator/launcher/__init__.py": 30,
-  "backtest_simulator/launcher/action_submitter.py": 590,
+  "backtest_simulator/launcher/action_submitter.py": 620,
   "backtest_simulator/launcher/clock.py": 180,
   "backtest_simulator/launcher/launcher.py": 1130,
   "backtest_simulator/launcher/poller.py": 140,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Two parity gaps remain explicit-in-source rather than stubbed:
 
 ## Test surface
 
-`tests/honesty/test_validation_parity.py` adds 10 tests:
+`tests/honesty/test_validation_parity.py` adds 11 tests:
 - `_allow_stage` AST-absent
 - All 6 stages bound to non-`_allow_stage` callables
 - Per-stage end-to-end denials (INTAKE × 2, PRICE, RISK, HEALTH,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
+# v2.0.6
+
+Validator-parity slice — five Nexus pipeline stages that were `_allow`
+stubs now run real `validate_*_stage` calls, mirroring Praxis paper-
+trade's `_build_validation_pipeline` with MMVP-lenient defaults
+(`RiskStageLimits()`, `PlatformLimitsStageLimits()`, `HealthStagePolicy()`,
+`PriceStageLimits` derived from `nexus_config`). Operator-supplied
+limits dial in real denial behavior — same dials Praxis exposes, no
+bts-specific knobs invented.
+
+## Real validators wired
+
+`backtest_simulator/honesty/capital.py::build_validation_pipeline`
+deletes `_allow_stage` and binds:
+
+- INTAKE → `validate_intake_stage(context, build_default_intake_hooks(nexus_config))`
+- RISK → `validate_risk_stage(context, RiskStageLimits())`
+- PRICE → `validate_price_stage(context, build_price_stage_limits_from_config(nexus_config), price_snapshot_provider())`
+- CAPITAL → unchanged (already real)
+- HEALTH → `validate_health_stage(context, health_snapshot_provider(), HealthStagePolicy())`
+- PLATFORM_LIMITS → `validate_platform_limits_stage(context, PlatformLimitsStageLimits(), platform_snapshot_provider())`
+
+The signature gains `nexus_config: InstanceConfig` (required), plus
+keyword-only `risk_limits`, `health_policy`, `platform_limits`, and
+three snapshot providers — same shape as Praxis.
+
+## Documented divergence (carried forward)
+
+Two parity gaps remain explicit-in-source rather than stubbed:
+
+1. `_check_declared_stop` and `_check_atr_sanity` continue to run as
+   bts-side INTAKE pre-hooks because `ValidationRequestContext` does
+   not expose `action.execution_params['stop_price']`. Their
+   docstrings now cite the closure path (Nexus PR extending the
+   context).
+2. The SELL close fast-path in `action_submitter._submit_translated`
+   stays in place because (a) the long-only strategy template does
+   not propagate `Action.trade_id` from BUY to SELL, and (b)
+   `CapitalController` has no `close_position` primitive. Both
+   resolutions are upstream Nexus/strategy work; the source comment
+   spells out the debt explicitly.
+
+## Test surface
+
+`tests/honesty/test_validation_parity.py` adds 10 tests:
+- `_allow_stage` AST-absent
+- All 6 stages bound to non-`_allow_stage` callables
+- Per-stage end-to-end denials (INTAKE × 2, PRICE, RISK, HEALTH,
+  PLATFORM_LIMITS) via `nexus_config` / limits / snapshot providers
+- INTAKE pre-hook docstrings cite parity divergence
+- SELL fast-path divergence documented in source
+
 # v2.0.5
 
 Package-cleanup slice — no functional change. Drops operator-local

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In the wider Vaquum architecture, Origo sits upstream as the data layer; Limen p
 
 - One-symbol historical backtest with strict no-look-ahead and per-fill measurement against the trade tape
 - Real Praxis `VenueAdapter` Protocol implementation backed by historical trades (`SimulatedVenueAdapter`)
-- Real Nexus runtime — `BacktestLauncher` is a Praxis `Launcher` subclass; the wired `action_submit` path is the same six-stage `ValidationPipeline` the live system uses
+- Real Nexus runtime — `BacktestLauncher` is a Praxis `Launcher` subclass; the wired `action_submit` path is the same six-stage `ValidationPipeline` the live system uses, with each stage running the real `validate_*_stage` from `nexus.core.validator` (MMVP-lenient defaults — operator-supplied `nexus_config` / limits / snapshot providers dial in real denial behavior, same dials Praxis paper-trade exposes)
 - Slippage, market-impact, and maker-fill models calibrated on the same tape, measured per fill (not adjusted on `fill_price` — the audit rejected the double-counting design)
 - ATR R-denominator gameability gate: stop-distance must clear `k * ATR(window)` from entry or the order is rejected pre-fill
 - Book-gap instrumentation: `(trigger_time - prev_sub_stop_time)` recorded per STOP/TP fill, surfaced on `bts run --output-format json`

--- a/backtest_simulator/honesty/capital.py
+++ b/backtest_simulator/honesty/capital.py
@@ -80,7 +80,18 @@ def _default_platform_snapshot() -> PlatformLimitsStageSnapshot:
 
 
 def _default_price_snapshot() -> PriceCheckSnapshot | None:
-    """Return `None`; MMVP `PriceStageLimits` are all-unset by default."""
+    """Return `None`; MMVP `PriceStageLimits` are all-unset by default.
+
+    Operator-supplied `nexus_config.max_spread_bps` together with a
+    real-tape-backed snapshot provider produces real PRICE denials.
+    A future tape-backed provider must NEVER paper over missing data
+    (e.g. by returning `Decimal('inf')` for `spread_bps`); a stale or
+    incomplete snapshot has to surface as a normal denial via
+    `PRICE_SYSTEM_DATA_UNAVAILABLE` so the operator sees the gap
+    rather than every BUY being silently rejected. Returning `None`
+    from this default keeps the gate disabled until a real provider
+    is wired.
+    """
     return None
 
 

--- a/backtest_simulator/honesty/capital.py
+++ b/backtest_simulator/honesty/capital.py
@@ -1,22 +1,22 @@
-"""Real-CAPITAL ValidationPipeline + 4-step CapitalController lifecycle driver."""
+"""Real six-stage ValidationPipeline + 4-step CapitalController lifecycle driver."""
 from __future__ import annotations
 
-# Part 2 invariant: every ENTER/EXIT action that reaches the venue
-# adapter must have first cleared the real Nexus CAPITAL validator AND
-# must pass through `check_and_reserve → send_order → order_ack →
-# order_fill` on a shared `CapitalController`. The other five validator
-# stages (INTAKE / RISK / PRICE / HEALTH / PLATFORM_LIMITS) are wired to
-# an `_allow` stub because Part 2 scope is "CAPITAL real, others _allow"
-# per `TODO.md`; they will land as real checks in a follow-up slice.
+# Slice #28 (validator parity): every Nexus pipeline stage runs a real
+# `validate_*_stage` call; no `_allow` stubs. The wiring mirrors the
+# Praxis paper-trade reference at `praxis/launcher.py::_build_validation_pipeline`
+# — same intake-hook-built-once pattern, same MMVP-lenient defaults
+# (`RiskStageLimits()`, `PlatformLimitsStageLimits()`, `HealthStagePolicy()`,
+# `PriceStageLimits` from config). Operator-supplied limits dial in
+# real validator behavior by passing a configured `nexus_config` and
+# richer snapshot providers; no new bts-specific knobs are invented.
 #
-# `build_validation_pipeline` returns the configured
-# `nexus.core.validator.ValidationPipeline` plus its `CapitalController`.
-# The controller is the SHARED instance the action-submitter and the
-# venue-fill bridge both drive — the pipeline's CAPITAL stage calls
-# `check_and_reserve` during validation, and the `CapitalLifecycleTracker`
-# feeds `send_order`, `order_ack`, and `order_fill` back in as Praxis's
-# event spine produces `CommandAccepted`, `OrderSubmitted`, and
-# `FillReceived` events.
+# `build_validation_pipeline` returns the configured pipeline plus its
+# `CapitalController`. The controller is the SHARED instance the
+# action-submitter and the venue-fill bridge both drive — the
+# pipeline's CAPITAL stage calls `check_and_reserve` during validation,
+# and the `CapitalLifecycleTracker` feeds `send_order`, `order_ack`,
+# and `order_fill` back in as Praxis's event spine produces
+# `CommandAccepted`, `OrderSubmitted`, and `FillReceived` events.
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -27,37 +27,86 @@ from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.validator import ValidationPipeline
 from nexus.core.validator.capital_stage import validate_capital_stage
+from nexus.core.validator.health_stage import (
+    HealthStagePolicy,
+    HealthStageSnapshot,
+    validate_health_stage,
+)
+from nexus.core.validator.intake_stage import (
+    build_default_intake_hooks,
+    validate_intake_stage,
+)
 from nexus.core.validator.pipeline_models import (
     ValidationDecision,
     ValidationRequestContext,
     ValidationStage,
 )
+from nexus.core.validator.platform_limits_stage import (
+    PlatformLimitsStageLimits,
+    PlatformLimitsStageSnapshot,
+    validate_platform_limits_stage,
+)
+from nexus.core.validator.price_stage import (
+    PriceCheckSnapshot,
+    build_price_stage_limits_from_config,
+    validate_price_stage,
+)
+from nexus.core.validator.risk_stage import RiskStageLimits, validate_risk_stage
+from nexus.instance_config import InstanceConfig
 
 _log = logging.getLogger(__name__)
 
 
-def _allow_stage(_ctx: ValidationRequestContext) -> ValidationDecision:
-    """`_allow` stub: unconditionally pass.
+def _default_health_snapshot() -> HealthStageSnapshot:
+    """Return a neutral-healthy `HealthStageSnapshot` for MMVP-lenient health.
 
-    Used for the Part 2 stages we deliberately leave open (INTAKE,
-    RISK, PRICE, HEALTH, PLATFORM_LIMITS). The backtest is not a
-    production intake; all of those checks are gate-only-at-live
-    concerns (order_rate, book staleness, etc.) that would reject
-    honest historical hypotheses.
+    Mirrors `praxis/launcher.py::_default_health_snapshot`. With
+    `HealthStagePolicy()`'s thresholds all-None this snapshot allows
+    every action; only operator-supplied policy + snapshot pair fires
+    a denial.
     """
-    return ValidationDecision(allowed=True)
+    return HealthStageSnapshot(
+        latency_ms=Decimal(0),
+        consecutive_failures=Decimal(0),
+        failure_rate=Decimal(0),
+        rate_limit_headroom=Decimal(1),
+        clock_drift_ms=Decimal(0),
+    )
+
+
+def _default_platform_snapshot() -> PlatformLimitsStageSnapshot:
+    """Return an empty `PlatformLimitsStageSnapshot` for MMVP defaults."""
+    return PlatformLimitsStageSnapshot()
+
+
+def _default_price_snapshot() -> PriceCheckSnapshot | None:
+    """Return `None`; MMVP `PriceStageLimits` are all-unset by default."""
+    return None
 
 
 def build_validation_pipeline(
     *,
+    nexus_config: InstanceConfig,
     capital_pool: Decimal,
     reservation_ttl_seconds: int = 86_400,
+    risk_limits: RiskStageLimits | None = None,
+    health_policy: HealthStagePolicy | None = None,
+    platform_limits: PlatformLimitsStageLimits | None = None,
+    health_snapshot_provider: Callable[[], HealthStageSnapshot] = _default_health_snapshot,
+    platform_snapshot_provider: Callable[[], PlatformLimitsStageSnapshot] = _default_platform_snapshot,
+    price_snapshot_provider: Callable[[], PriceCheckSnapshot | None] = _default_price_snapshot,
 ) -> tuple[ValidationPipeline, CapitalController, CapitalState]:
-    """Construct the Part 2 validator stack: CAPITAL real, others _allow.
+    """Build the six-stage validator pipeline that runs every backtest action.
 
-    Returns the pipeline, the `CapitalController` (the backtest
-    launcher drives its 4-step lifecycle), and the `CapitalState`
-    snapshot for conservation assertions.
+    Each stage closure captures stage-specific configuration derived
+    once from `nexus_config`; mutable runtime state (health snapshot,
+    platform snapshot, price snapshot) is read on every call via the
+    supplied providers. MMVP defaults are deliberately lenient — same
+    posture Praxis paper-trade ships (`RiskStageLimits()`,
+    `PlatformLimitsStageLimits()`, `HealthStagePolicy()` all
+    threshold-None; `PriceStageLimits` derived from config which
+    inherits the all-unset posture). Operator-supplied limits + a
+    configured `nexus_config` dial in real denial behavior.
 
     `reservation_ttl_seconds` defaults to 86_400 (one day) because
     backtest submission-to-fill spans frozen-minute main ticks that
@@ -70,18 +119,50 @@ def build_validation_pipeline(
     state = CapitalState(capital_pool=capital_pool)
     controller = CapitalController(state)
 
-    def capital_validator(context: ValidationRequestContext) -> ValidationDecision:
+    intake_hooks = build_default_intake_hooks(nexus_config)
+    resolved_risk_limits = risk_limits if risk_limits is not None else RiskStageLimits()
+    resolved_health_policy = (
+        health_policy if health_policy is not None else HealthStagePolicy()
+    )
+    resolved_platform_limits = (
+        platform_limits if platform_limits is not None
+        else PlatformLimitsStageLimits()
+    )
+    price_limits = build_price_stage_limits_from_config(nexus_config)
+
+    def intake(context: ValidationRequestContext) -> ValidationDecision:
+        return validate_intake_stage(context, hooks=intake_hooks)
+
+    def risk(context: ValidationRequestContext) -> ValidationDecision:
+        return validate_risk_stage(context, resolved_risk_limits)
+
+    def price(context: ValidationRequestContext) -> ValidationDecision:
+        return validate_price_stage(
+            context, price_limits, price_snapshot_provider(),
+        )
+
+    def capital(context: ValidationRequestContext) -> ValidationDecision:
         return validate_capital_stage(
             context, controller, ttl_seconds=reservation_ttl_seconds,
         )
 
+    def health(context: ValidationRequestContext) -> ValidationDecision:
+        return validate_health_stage(
+            context, health_snapshot_provider(), resolved_health_policy,
+        )
+
+    def platform(context: ValidationRequestContext) -> ValidationDecision:
+        return validate_platform_limits_stage(
+            context, resolved_platform_limits, platform_snapshot_provider(),
+        )
+
     validators: dict[ValidationStage, Callable[[ValidationRequestContext], ValidationDecision]] = {
-        ValidationStage.INTAKE: _allow_stage,
-        ValidationStage.RISK: _allow_stage,
-        ValidationStage.PRICE: _allow_stage,
-        ValidationStage.CAPITAL: capital_validator,
-        ValidationStage.HEALTH: _allow_stage,
-        ValidationStage.PLATFORM_LIMITS: _allow_stage,
+        ValidationStage.INTAKE: intake,
+        ValidationStage.RISK: risk,
+        ValidationStage.PRICE: price,
+        ValidationStage.CAPITAL: capital,
+        ValidationStage.HEALTH: health,
+        ValidationStage.PLATFORM_LIMITS: platform,
     }
     pipeline = ValidationPipeline(validators)
     return pipeline, controller, state

--- a/backtest_simulator/launcher/action_submitter.py
+++ b/backtest_simulator/launcher/action_submitter.py
@@ -294,6 +294,7 @@ class SubmitterBindings:
     state: InstanceState
     praxis_outbound: PraxisOutbound
     validation_pipeline: ValidationPipeline
+    strategy_budget: Decimal
     # Slice #28 — pipeline.validate's CAPITAL stage runs before
     # HEALTH/PLATFORM_LIMITS, so a denial from a later stage carries
     # the reservation forward (per nexus pipeline_executor). Without
@@ -304,7 +305,6 @@ class SubmitterBindings:
     # state. Default-None for tests that don't care (a denied
     # decision with reservation=None is a no-op release path).
     capital_controller: CapitalController | None = None
-    strategy_budget: Decimal = Decimal('0')
     touch_provider: Callable[[str], Decimal | None] | None = None
     tick_provider: Callable[[str], Decimal] | None = None
     # Slice #17 Task 29 — ATR R-denominator gameability gate.

--- a/backtest_simulator/launcher/action_submitter.py
+++ b/backtest_simulator/launcher/action_submitter.py
@@ -520,13 +520,23 @@ def _submit_translated(
                 decision.reservation.reservation_id,
             )
             if not release_result.success:
-                _log.warning(
-                    'pipeline-denied reservation release failed: '
-                    'reservation_id=%s reason=%s category=%s',
-                    decision.reservation.reservation_id,
-                    release_result.reason,
-                    release_result.category,
+                # Fail loud — the reservation was just minted by the same
+                # pipeline.validate() call on the same controller; any
+                # non-success here is a wiring/state bug (controller
+                # mismatch, concurrent release, lost reservation), not an
+                # expected race. Mirrors `CapitalLifecycleTracker.record_rejection`'s
+                # pattern at honesty/capital.py:461. Letting the bug
+                # through with a warning would silently re-introduce
+                # the very leak this branch exists to prevent
+                # (bit-mis no-defects-conviction P1).
+                msg = (
+                    f'pipeline-denied reservation release failed: '
+                    f'reservation_id={decision.reservation.reservation_id} '
+                    f'failed_stage={decision.failed_stage} '
+                    f'reason={release_result.reason!r} '
+                    f'category={release_result.category}'
                 )
+                raise RuntimeError(msg)
         _log.warning(
             'validation denied: stage=%s reason_code=%s message=%s command_id=%s',
             decision.failed_stage.value if decision.failed_stage else None,

--- a/backtest_simulator/launcher/action_submitter.py
+++ b/backtest_simulator/launcher/action_submitter.py
@@ -12,6 +12,7 @@ from enum import Enum
 from types import SimpleNamespace
 from typing import cast
 
+from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.instance_state import InstanceState
 from nexus.core.domain.order_types import ExecutionMode as _NexusExecutionMode
@@ -293,7 +294,17 @@ class SubmitterBindings:
     state: InstanceState
     praxis_outbound: PraxisOutbound
     validation_pipeline: ValidationPipeline
-    strategy_budget: Decimal
+    # Slice #28 — pipeline.validate's CAPITAL stage runs before
+    # HEALTH/PLATFORM_LIMITS, so a denial from a later stage carries
+    # the reservation forward (per nexus pipeline_executor). Without
+    # explicit release, available capital leaks. The action_submitter
+    # uses this controller to release reservations attached to denied
+    # decisions; the launcher constructs both pipeline + controller
+    # from the same `build_validation_pipeline` call so they share
+    # state. Default-None for tests that don't care (a denied
+    # decision with reservation=None is a no-op release path).
+    capital_controller: CapitalController | None = None
+    strategy_budget: Decimal = Decimal('0')
     touch_provider: Callable[[str], Decimal | None] | None = None
     tick_provider: Callable[[str], Decimal] | None = None
     # Slice #17 Task 29 — ATR R-denominator gameability gate.
@@ -337,10 +348,16 @@ def build_action_submitter(
         calls can tie back to the original reservation.
       - `on_submit` is the pre-existing drain hook the clock loop uses.
 
-    The only stage this pipeline actually enforces in Part 2 is CAPITAL;
-    INTAKE / RISK / PRICE / HEALTH / PLATFORM_LIMITS are `_allow` stubs
-    as documented in `backtest_simulator.honesty.capital`. ABORT flows
-    through `praxis_outbound.send_abort` unchanged.
+    Slice #28: every Nexus pipeline stage runs a real `validate_*_stage`
+    call. INTAKE / RISK / PRICE / CAPITAL / HEALTH / PLATFORM_LIMITS are
+    all backed by their respective Nexus validators with MMVP-lenient
+    defaults; operator-supplied limits + snapshot providers in
+    `backtest_simulator.honesty.capital.build_validation_pipeline` dial
+    in real denial behavior. CAPITAL runs before HEALTH/PLATFORM_LIMITS
+    in stage order, so a late-stage denial that carries the reservation
+    forward triggers an explicit `capital_controller.release_reservation`
+    in `_submit_translated`. ABORT flows through `praxis_outbound.send_abort`
+    unchanged.
     """
     def _submit(actions: list[Action], strategy_id: str) -> None:
         for raw_action in actions:
@@ -492,6 +509,24 @@ def _submit_translated(
         return command_id, decision, context
     decision = bindings.validation_pipeline.validate(context)
     if not decision.allowed:
+        # Slice #28: CAPITAL is stage 4 of 6, so HEALTH/PLATFORM_LIMITS
+        # denials carry the CAPITAL-stage reservation forward in the
+        # denied decision (nexus pipeline_executor preserves it). The
+        # action is dropped without reaching Praxis, so no fill / no
+        # `order_ack` / no `order_fill` will retire the reservation.
+        # Release it explicitly so available capital is not leaked.
+        if decision.reservation is not None and bindings.capital_controller is not None:
+            release_result = bindings.capital_controller.release_reservation(
+                decision.reservation.reservation_id,
+            )
+            if not release_result.success:
+                _log.warning(
+                    'pipeline-denied reservation release failed: '
+                    'reservation_id=%s reason=%s category=%s',
+                    decision.reservation.reservation_id,
+                    release_result.reason,
+                    release_result.category,
+                )
         _log.warning(
             'validation denied: stage=%s reason_code=%s message=%s command_id=%s',
             decision.failed_stage.value if decision.failed_stage else None,

--- a/backtest_simulator/launcher/action_submitter.py
+++ b/backtest_simulator/launcher/action_submitter.py
@@ -294,7 +294,6 @@ class SubmitterBindings:
     state: InstanceState
     praxis_outbound: PraxisOutbound
     validation_pipeline: ValidationPipeline
-    strategy_budget: Decimal
     # Slice #28 — pipeline.validate's CAPITAL stage runs before
     # HEALTH/PLATFORM_LIMITS, so a denial from a later stage carries
     # the reservation forward (per nexus pipeline_executor). Without
@@ -302,9 +301,10 @@ class SubmitterBindings:
     # uses this controller to release reservations attached to denied
     # decisions; the launcher constructs both pipeline + controller
     # from the same `build_validation_pipeline` call so they share
-    # state. Default-None for tests that don't care (a denied
-    # decision with reservation=None is a no-op release path).
-    capital_controller: CapitalController | None = None
+    # state. REQUIRED — making it optional would let a caller silently
+    # regress to the leak shape (slice-#28 audit, finding 5).
+    capital_controller: CapitalController
+    strategy_budget: Decimal
     touch_provider: Callable[[str], Decimal | None] | None = None
     tick_provider: Callable[[str], Decimal] | None = None
     # Slice #17 Task 29 — ATR R-denominator gameability gate.
@@ -515,7 +515,7 @@ def _submit_translated(
         # action is dropped without reaching Praxis, so no fill / no
         # `order_ack` / no `order_fill` will retire the reservation.
         # Release it explicitly so available capital is not leaked.
-        if decision.reservation is not None and bindings.capital_controller is not None:
+        if decision.reservation is not None:
             release_result = bindings.capital_controller.release_reservation(
                 decision.reservation.reservation_id,
             )

--- a/backtest_simulator/launcher/action_submitter.py
+++ b/backtest_simulator/launcher/action_submitter.py
@@ -114,6 +114,8 @@ _ACTION_TYPE_TO_VALIDATION_ACTION: dict[ActionType, ValidationAction] = {
 }
 
 
+
+
 # --- Nexus -> Praxis enum converters ----------------------------------------
 # Nexus and Praxis define separate Enum classes for the same domain
 # concepts (ExecutionMode, OrderType, OrderSide, MakerPreference,
@@ -430,14 +432,14 @@ def _submit_translated(
         strategy_id=strategy_id, action=action,
         strategy_budget=bindings.strategy_budget,
     )
-    # Part 2 INTAKE hook: declared-stop enforcement. Long-only strategy
-    # convention — BUY opens a long (requires protective stop), SELL
-    # closes a long (is itself the exit, no new stop). The hook runs
-    # BEFORE `validation_pipeline.validate` because the pipeline's
-    # INTAKE stage is `_allow` in Part 2 and the stop is carried on
-    # `action.execution_params`, which isn't accessible from within a
-    # `StageValidator`. Slice #17 Task 29 layers the ATR sanity check
-    # on top: stop must be ≥ `gate.k * ATR(window)` from entry.
+    # BTS-side INTAKE pre-hook supplementing the real Nexus INTAKE stage.
+    # Slice #28 lit up the pipeline's INTAKE with real
+    # `validate_intake_stage(...)` checks; these two hooks layer on top
+    # because the data they need (`execution_params['stop_price']`) is
+    # not on `ValidationRequestContext`. Closure path: a Nexus PR
+    # extending `ValidationRequestContext.execution_params`. Long-only
+    # strategy convention — BUY opens a long (requires protective stop),
+    # SELL closes a long (is itself the exit, no new stop).
     intake_decision = _check_declared_stop(action, context)
     if intake_decision is None:
         intake_decision = _check_atr_sanity(
@@ -455,25 +457,23 @@ def _submit_translated(
             context.command_id,
         )
         return None
-    # SELL ENTER in our long-only strategy is the EXIT LEG of an
-    # already-open long — it reduces an existing position rather than
-    # opening a new one. The action_submitter fast-path skips
-    # `validation_pipeline.validate` (and therefore the CAPITAL
-    # reservation) — see TODO Task 27 for the architectural
-    # decision: `CapitalController` has no `close_position`
-    # primitive, so routing the SELL through `validate` would
-    # either over-reserve (CAPITAL.check_and_reserve always
-    # adds claim) or no-op (the current skip), neither of which
-    # is the canonical close lifecycle. Instead the close lands
-    # in the launcher's adapter wrapper post-fill via
-    # `CapitalLifecycleTracker.record_close_position`, which
-    # mirrors `CapitalController.order_fill` exactly: releases
+    # SELL fast-path: long-only convention treats `SELL+ENTER` as the
+    # close of an open long. The fast-path bypasses
+    # `validation_pipeline.validate` because (a) the bts long-only
+    # strategy template emits SELLs without propagating the BUY's
+    # `trade_id`, so `make_reference_integrity_hook` would deny every
+    # close with `INTAKE_TRADE_REFERENCE_INVALID`; (b) `CapitalController`
+    # has no `close_position` primitive, so a real CAPITAL stage on
+    # SELL would over-reserve. Closure path: a Nexus PR adding
+    # `close_position` AND a strategy-template change to propagate
+    # `trade_id` from BUY to SELL. Both upstream; tracked as
+    # follow-up. The bts-side close accounting still lands in the
+    # launcher's adapter wrapper via
+    # `CapitalLifecycleTracker.record_close_position`, which mirrors
+    # `CapitalController.order_fill` exactly: releases
     # `cost_basis + entry_fees` from `position_notional` and
-    # decrements `per_strategy_deployed[strategy_id]` by the
-    # same amount. `capital_pool` stays untouched (immutable
-    # strategy budget; SELL proceeds are realized PnL, not new
-    # budget). Realized PnL surfaces on the lifecycle log line
-    # and as the trade-pair PnL in `cli/_metrics.print_run`.
+    # decrements `per_strategy_deployed[strategy_id]`. `capital_pool`
+    # stays untouched.
     if action.direction == OrderSide.SELL:
         decision = ValidationDecision(allowed=True)
         cmd = translate_to_trade_command(
@@ -482,7 +482,7 @@ def _submit_translated(
         cmd = _to_praxis_enums(cmd)
         command_id = bindings.praxis_outbound.send_command(cmd)
         _log.info(
-            'backtest action submitted (SELL close — CAPITAL skipped)',
+            'backtest action submitted (SELL close — pipeline bypassed)',
             extra={
                 'strategy_id': strategy_id,
                 'action_type': action.action_type.value,
@@ -611,6 +611,15 @@ def _check_declared_stop(
 ) -> ValidationDecision | None:
     """Deny BUY-ENTER that lacks a declared stop_price.
 
+    BTS-side pre-hook supplementing the real Nexus INTAKE stage.
+    Slice #28 lit up `validate_intake_stage` (order-rate, duplicate-
+    window, reference-integrity, mode, notional, budget). This hook
+    runs in addition because `ValidationRequestContext` does not carry
+    `action.execution_params['stop_price']` and the stop check needs
+    that field. Closure path: a Nexus PR extending
+    `ValidationRequestContext.execution_params` lets this hook
+    collapse into the pipeline's INTAKE stage.
+
     The long-only strategy template writes stop_price onto
     `execution_params['stop_price']` for BUYs only (SELLs close an
     open long and are themselves the exit). A missing stop on a BUY
@@ -650,6 +659,14 @@ def _check_atr_sanity(
 ) -> ValidationDecision | None:
     """Reject ENTER+BUY whose declared stop is closer than `k * ATR(window)`.
 
+    BTS-side pre-hook supplementing the real Nexus INTAKE stage. The
+    pipeline's INTAKE runs `validate_intake_stage` with the standard
+    Praxis hooks; this ATR-floor hook runs in addition because the
+    data it needs (`execution_params['stop_price']` plus the symbol's
+    pre-decision ATR window) is not on `ValidationRequestContext`.
+    Closure path: a Nexus PR extending `ValidationRequestContext` so
+    this floor lands inside `validate_intake_stage` itself.
+
     Slice #17 Task 29 closes the R-denominator gameability vector
     `_check_declared_stop` only half-blocks: a 1 bp stop reaches
     Praxis untouched and the R̄ in `bts sweep` becomes a knob the
@@ -658,24 +675,12 @@ def _check_atr_sanity(
     missing (caller already handled), or when ATR allows. Else
     returns a denial with reason_code prefixed `ATR_`.
 
-    BTS-ONLY contract — accepted divergence vs paper/live. Audit
-    round 2 P1 flagged this: the gate runs in action_submitter
-    BEFORE `validation_pipeline.validate()` and BEFORE any
-    command reaches Praxis, so a backtest can deny an entry that
-    paper/live would still take. The asymmetry is accepted because
-    the gate is bts-measurement-protection, not paper/live
-    behavior modeling — paper/live measures realized PnL, bts
-    measures R-multiples on R̄, and only the latter is
-    gameable by tightening stops. The same shape applies to
-    `_check_declared_stop` (which also runs as a bts-side
-    INTAKE shim, since Nexus's `ValidationRequestContext` does
-    not expose `execution_params['stop_price']` to a
-    `StageValidator`). Upstreaming this floor to paper/live
-    requires either (a) extending `ValidationRequestContext` so
-    Nexus's pipeline can read `stop_price` (Nexus PR), or (b)
-    moving the floor into the strategy template itself so it
-    runs upstream of any deployment. Either is out of slice
-    scope; tracked as a follow-up.
+    BTS-only floor — paper/live measures realized PnL, bts measures
+    R-multiples on R̄, and only the latter is gameable by tightening
+    stops. Upstreaming this floor to paper/live requires either (a)
+    the Nexus context extension above, or (b) moving the floor into
+    the strategy template itself so it runs upstream of any
+    deployment. Both are out of slice scope.
 
     Entry-price proxy priority (codex round 1 P1: must match the
     R-denominator's actual entry — a stale seed price drifts vs

--- a/backtest_simulator/launcher/launcher.py
+++ b/backtest_simulator/launcher/launcher.py
@@ -1126,6 +1126,7 @@ class BacktestLauncher(Launcher):
         manifest = load_manifest(inst.manifest_path)
         allocated_capital = manifest.allocated_capital
         pipeline, controller, capital_state = build_validation_pipeline(
+            nexus_config=nexus_config,
             capital_pool=allocated_capital,
         )
         state = InstanceState(capital=capital_state)

--- a/backtest_simulator/launcher/launcher.py
+++ b/backtest_simulator/launcher/launcher.py
@@ -1160,6 +1160,7 @@ class BacktestLauncher(Launcher):
                 nexus_config=nexus_config, state=state,
                 praxis_outbound=praxis_outbound,
                 validation_pipeline=pipeline,
+                capital_controller=controller,
                 strategy_budget=allocated_capital,
                 touch_provider=touch_provider,
                 tick_provider=tick_provider,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "backtest_simulator"
-version = "2.0.5"
+version = "2.0.6"
 description = "Honest, gate-enforced backtester for unmodified Nexus strategies against unmodified Praxis."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -188,6 +188,15 @@ max-statements = 50
 # VenueAdapter Protocol signature (10 args). A helper-extraction
 # refactor would break the runtime_checkable isinstance() check.
 "backtest_simulator/venue/simulated.py" = ["PLR0913"]
+# `build_validation_pipeline` mirrors Praxis's `_build_validation_pipeline`
+# parameter shape (slice #28). The 9 kwargs (`nexus_config`,
+# `capital_pool`, `reservation_ttl_seconds`, three optional
+# limits/policy injection points, three snapshot providers) are the
+# real parity surface — collapsing them into a config bundle would
+# diverge from the Praxis reference and lose the per-stage knob
+# clarity. Same posture as `launcher.py`'s VenueAdapter Protocol
+# exemption above: the parameter count is the contract.
+"backtest_simulator/honesty/capital.py" = ["PLR0913"]
 # launcher.py's `wrapped_submit` mirrors the 9-param Praxis Protocol
 # signature (it wraps SimulatedVenueAdapter.submit_order without
 # changing arity).

--- a/tests/honesty/test_adapter_wrapper_paths.py
+++ b/tests/honesty/test_adapter_wrapper_paths.py
@@ -19,6 +19,7 @@ from types import SimpleNamespace
 import pytest
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OrderSide
+from nexus.instance_config import InstanceConfig as NexusInstanceConfig
 
 from backtest_simulator.honesty import (
     CapitalLifecycleTracker,
@@ -78,6 +79,7 @@ def _tracker_with_pending(
 
 def test_overshoot_raises_capital_overshoot_error() -> None:
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = _tracker_with_pending(capital_state, notional=Decimal('1000'))
@@ -124,6 +126,7 @@ def test_partially_filled_releases_residual_reservation() -> None:
     This test pins the expected-post-state invariants.
     """
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = _tracker_with_pending(capital_state, notional=Decimal('1000'))
@@ -187,6 +190,7 @@ def test_expired_zero_fill_releases_reservation() -> None:
     (b) capital_state.reservation_notional != 0 (lock leaked).
     """
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = _tracker_with_pending(capital_state, notional=Decimal('1000'))
@@ -240,6 +244,7 @@ def test_unmatched_buy_raises_runtime_error() -> None:
     # No pending reservation → a BUY that reaches the wrapper has
     # bypassed the CAPITAL gate. Must fail loud.
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(_controller)  # empty tracker
@@ -265,6 +270,7 @@ def test_unmatched_sell_is_accepted() -> None:
     # SELL-as-close has no pending reservation by design; the wrapper
     # must NOT raise for SELL.
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(_controller)
@@ -332,6 +338,7 @@ def test_buy_fill_records_open_position_through_wrapper() -> None:
     BUY side surfaces with a precise message.
     """
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = _tracker_with_pending(capital_state, notional=Decimal('1000'))
@@ -384,6 +391,7 @@ def test_buy_then_sell_close_releases_position_and_attribution() -> None:
     over-deployment or silently double-books.
     """
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = _tracker_with_pending(capital_state, notional=Decimal('1000'))
@@ -462,6 +470,7 @@ def test_partial_sell_close_shrinks_head_keeps_residual() -> None:
     in the ledger for the next SELL to finish.
     """
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = _tracker_with_pending(capital_state, notional=Decimal('1000'))
@@ -530,6 +539,7 @@ def test_sell_close_without_open_position_raises() -> None:
     machine bug rather than silently corrupting capital.
     """
     _pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     from nexus.core.validator.capital_stage import CapitalController

--- a/tests/honesty/test_capital_lifecycle.py
+++ b/tests/honesty/test_capital_lifecycle.py
@@ -21,6 +21,7 @@ from nexus.core.validator.pipeline_models import (
     ValidationRequestContext,
     ValidationStage,
 )
+from nexus.instance_config import InstanceConfig as NexusInstanceConfig
 
 from backtest_simulator.honesty import (
     CapitalLifecycleTracker,
@@ -63,6 +64,7 @@ def _ctx(
 
 def test_build_pipeline_has_all_six_stages() -> None:
     pipeline, _controller, _state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     stages = set(pipeline.stage_order)
@@ -80,6 +82,7 @@ def test_pipeline_accepts_affordable_enter() -> None:
     # Affordable: notional well under budget, CAPITAL approves,
     # other stages are _allow passes. Decision carries a reservation.
     pipeline, _controller, state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     # Reuse the pipeline's CapitalState — that's what CAPITAL reads.
@@ -106,6 +109,7 @@ def test_pipeline_denies_per_trade_limit_breach() -> None:
     # 15% per-trade cap: a 20k notional against a 100k budget is
     # 20% and must be denied at CAPITAL.
     pipeline, _controller, state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     ctx = _ctx(notional=Decimal('20000'), fees=Decimal('0'), budget=Decimal('100000'))
@@ -130,6 +134,7 @@ def _instance_state_sharing(capital_state):
 def test_lifecycle_happy_path() -> None:
     # Walk the 4-step lifecycle end-to-end: reserve → send → ack → fill.
     pipeline, controller, state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)
@@ -163,6 +168,7 @@ def test_lifecycle_happy_path() -> None:
 
 def test_lifecycle_fail_loud_on_skip_reservation() -> None:
     _pipeline, controller, _state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)
@@ -173,6 +179,7 @@ def test_lifecycle_fail_loud_on_skip_reservation() -> None:
 
 def test_lifecycle_fail_loud_on_fill_before_send() -> None:
     pipeline, controller, state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)
@@ -203,6 +210,7 @@ def test_lifecycle_fail_loud_on_fill_before_send() -> None:
 
 def test_declared_stop_lookup_roundtrip() -> None:
     _pipeline, controller, _state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)
@@ -220,11 +228,12 @@ def test_declared_stop_lookup_roundtrip() -> None:
 
 def test_record_rejection_releases_reservation() -> None:
     _pipeline, controller, state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)
     # Reserve via pipeline so the controller has the reservation.
-    _pipeline, _, _ = build_validation_pipeline(capital_pool=Decimal('100000'))
+    _pipeline, _, _ = build_validation_pipeline(nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'), capital_pool=Decimal('100000'))
     # Use the same controller for the tracker's pipeline.
     # (build_validation_pipeline creates a fresh controller each call.)
     ctx = _ctx()
@@ -262,6 +271,7 @@ def test_mutation_fill_without_pending_raises() -> None:
     # Injected bug: a hypothetical path calls record_ack_and_fill
     # without a prior record_reservation. Must not silently no-op.
     _pipeline, controller, _state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)
@@ -276,6 +286,7 @@ def test_mutation_double_fill_raises() -> None:
     # Injected bug: record_ack_and_fill called twice on the same
     # command_id. The second call must fail because pending is popped.
     pipeline, controller, state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     tracker = CapitalLifecycleTracker(controller)

--- a/tests/honesty/test_inverse_prescient.py
+++ b/tests/honesty/test_inverse_prescient.py
@@ -194,7 +194,7 @@ def _next_bar_label(prices: list[Decimal], i: int) -> int:
 def test_inverse_prescient_loses_catastrophically() -> None:
     """Sign-flipped prescient on alternating tape: per-pair PnL < 0, total <-1%."""
     trades, signal_times, prices = _alternating_tape()
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=_INITIAL_CAPITAL,
     )
@@ -207,6 +207,7 @@ def test_inverse_prescient_loses_catastrophically() -> None:
         state=InstanceState(capital=capital_state),
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+            capital_controller=controller,
         strategy_budget=_INITIAL_CAPITAL,
     )
     submit = build_action_submitter(bindings)

--- a/tests/honesty/test_inverse_prescient.py
+++ b/tests/honesty/test_inverse_prescient.py
@@ -195,6 +195,7 @@ def test_inverse_prescient_loses_catastrophically() -> None:
     """Sign-flipped prescient on alternating tape: per-pair PnL < 0, total <-1%."""
     trades, signal_times, prices = _alternating_tape()
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=_INITIAL_CAPITAL,
     )
     outbound = _OutboundCapture()

--- a/tests/honesty/test_sanity_buy_hold.py
+++ b/tests/honesty/test_sanity_buy_hold.py
@@ -153,6 +153,7 @@ def test_sanity_buy_hold() -> None:
     trades = _trades_dataframe()
     initial_pool = Decimal('100000')
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=initial_pool,
     )
     outbound = _OutboundCapture()

--- a/tests/honesty/test_sanity_buy_hold.py
+++ b/tests/honesty/test_sanity_buy_hold.py
@@ -152,7 +152,7 @@ def test_sanity_buy_hold() -> None:
     """Buy at first signal, hold, sell at last; return within ±5 bps of reference."""
     trades = _trades_dataframe()
     initial_pool = Decimal('100000')
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=initial_pool,
     )
@@ -165,6 +165,7 @@ def test_sanity_buy_hold() -> None:
         state=InstanceState(capital=capital_state),
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+            capital_controller=controller,
         strategy_budget=Decimal('100000'),
     )
     submit = build_action_submitter(bindings)

--- a/tests/honesty/test_sanity_over_trading.py
+++ b/tests/honesty/test_sanity_over_trading.py
@@ -212,6 +212,7 @@ def test_sanity_over_trading() -> None:
     trades, signal_times = _paired_zero_gross_tape(n_signals)
     initial_pool = Decimal('100000')
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=initial_pool,
     )
     outbound = _OutboundCapture()

--- a/tests/honesty/test_sanity_over_trading.py
+++ b/tests/honesty/test_sanity_over_trading.py
@@ -211,7 +211,7 @@ def test_sanity_over_trading() -> None:
     n_signals = 20  # 10 BUY + 10 SELL = 10 round-trip pairs
     trades, signal_times = _paired_zero_gross_tape(n_signals)
     initial_pool = Decimal('100000')
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=initial_pool,
     )
@@ -224,6 +224,7 @@ def test_sanity_over_trading() -> None:
         state=InstanceState(capital=capital_state),
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+            capital_controller=controller,
         strategy_budget=initial_pool,
     )
     submit = build_action_submitter(bindings)

--- a/tests/honesty/test_sanity_random.py
+++ b/tests/honesty/test_sanity_random.py
@@ -308,7 +308,7 @@ def _run_production_path(seed: int, trades: pl.DataFrame, signal_times: list[dat
     in Tasks 2/3/4. Returns the outbound command count for assertion
     by the caller against the strategy's emitted action count.
     """
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=_INITIAL_CAPITAL,
     )
@@ -321,6 +321,7 @@ def _run_production_path(seed: int, trades: pl.DataFrame, signal_times: list[dat
         state=InstanceState(capital=capital_state),
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+            capital_controller=controller,
         strategy_budget=_INITIAL_CAPITAL,
     )
     submit = build_action_submitter(bindings)

--- a/tests/honesty/test_sanity_random.py
+++ b/tests/honesty/test_sanity_random.py
@@ -309,6 +309,7 @@ def _run_production_path(seed: int, trades: pl.DataFrame, signal_times: list[dat
     by the caller against the strategy's emitted action count.
     """
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=_INITIAL_CAPITAL,
     )
     outbound = _OutboundCapture()

--- a/tests/honesty/test_sanity_zero_trade.py
+++ b/tests/honesty/test_sanity_zero_trade.py
@@ -29,6 +29,7 @@ from decimal import Decimal
 from types import SimpleNamespace
 
 from nexus.core.domain.operational_mode import OperationalMode
+from nexus.instance_config import InstanceConfig as NexusInstanceConfig
 from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.signal import Signal
@@ -120,7 +121,6 @@ def test_sanity_zero_trade_through_real_action_submitter() -> None:
 
     from nexus.core.validator.pipeline_models import InstanceState
     from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
-    from nexus.instance_config import InstanceConfig as NexusInstanceConfig
 
     from backtest_simulator.honesty import (
         assert_conservation,
@@ -145,6 +145,7 @@ def test_sanity_zero_trade_through_real_action_submitter() -> None:
 
     initial_pool = Decimal('100000')
     pipeline, controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=initial_pool,
     )
 

--- a/tests/honesty/test_sanity_zero_trade.py
+++ b/tests/honesty/test_sanity_zero_trade.py
@@ -174,6 +174,7 @@ def test_sanity_zero_trade_through_real_action_submitter() -> None:
         state=InstanceState(capital=capital_state),
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+            capital_controller=controller,
         strategy_budget=Decimal('100000'),
     )
     submit = build_action_submitter(bindings)

--- a/tests/honesty/test_sell_close_semantics.py
+++ b/tests/honesty/test_sell_close_semantics.py
@@ -64,6 +64,7 @@ def test_sell_close_does_not_reserve_capital() -> None:
     # double-commit).
     outbound = _OutboundStub()
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     state = InstanceState(capital=capital_state)
@@ -107,6 +108,7 @@ def test_sell_close_still_fires_on_submit() -> None:
     # the drain for SELL would hang the clock.
     outbound = _OutboundStub()
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     state = InstanceState(capital=capital_state)

--- a/tests/honesty/test_sell_close_semantics.py
+++ b/tests/honesty/test_sell_close_semantics.py
@@ -63,7 +63,7 @@ def test_sell_close_does_not_reserve_capital() -> None:
     # After a SELL close, reservation_notional MUST still be zero (no
     # double-commit).
     outbound = _OutboundStub()
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
@@ -84,6 +84,7 @@ def test_sell_close_does_not_reserve_capital() -> None:
             state=state,
             praxis_outbound=cast(PraxisOutbound, outbound),
             validation_pipeline=pipeline,
+            capital_controller=controller,
             strategy_budget=Decimal('100000'),
         ),
         on_reservation=on_reservation,
@@ -107,7 +108,7 @@ def test_sell_close_still_fires_on_submit() -> None:
     # drain counter is how we know the venue fill completed. Skipping
     # the drain for SELL would hang the clock.
     outbound = _OutboundStub()
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
@@ -121,6 +122,7 @@ def test_sell_close_still_fires_on_submit() -> None:
             state=state,
             praxis_outbound=cast(PraxisOutbound, outbound),
             validation_pipeline=pipeline,
+            capital_controller=controller,
             strategy_budget=Decimal('100000'),
         ),
         on_submit=submitted.append,

--- a/tests/honesty/test_shuffle_bars.py
+++ b/tests/honesty/test_shuffle_bars.py
@@ -264,6 +264,7 @@ def _run_buy_hold_on_tape(
     submit = None
     if outbound is not None:
         pipeline, _controller, capital_state = build_validation_pipeline(
+            nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
             capital_pool=_INITIAL_CAPITAL,
         )
         bindings = SubmitterBindings(

--- a/tests/honesty/test_shuffle_bars.py
+++ b/tests/honesty/test_shuffle_bars.py
@@ -263,7 +263,7 @@ def _run_buy_hold_on_tape(
     )
     submit = None
     if outbound is not None:
-        pipeline, _controller, capital_state = build_validation_pipeline(
+        pipeline, controller, capital_state = build_validation_pipeline(
             nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
             capital_pool=_INITIAL_CAPITAL,
         )
@@ -274,6 +274,7 @@ def _run_buy_hold_on_tape(
             state=InstanceState(capital=capital_state),
             praxis_outbound=cast(PraxisOutbound, outbound),
             validation_pipeline=pipeline,
+            capital_controller=controller,
             strategy_budget=_INITIAL_CAPITAL,
         )
         submit = build_action_submitter(bindings)

--- a/tests/honesty/test_validation_parity.py
+++ b/tests/honesty/test_validation_parity.py
@@ -11,10 +11,12 @@ from __future__ import annotations
 import ast
 from decimal import Decimal
 from pathlib import Path
+from typing import cast
 
 from nexus.core.domain.capital_state import CapitalState
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.core.domain.risk_state import RiskState
 from nexus.core.validator.health_stage import (
     HealthMetricThresholds,
@@ -31,12 +33,16 @@ from nexus.core.validator.platform_limits_stage import (
 )
 from nexus.core.validator.price_stage import PriceCheckSnapshot
 from nexus.core.validator.risk_stage import RiskStageLimits
+from nexus.infrastructure.praxis_connector.praxis_outbound import PraxisOutbound
 from nexus.instance_config import InstanceConfig
+from nexus.strategy.action import Action, ActionType
 
 from backtest_simulator.honesty import build_validation_pipeline
 from backtest_simulator.launcher.action_submitter import (
+    SubmitterBindings,
     _check_atr_sanity,
     _check_declared_stop,
+    build_action_submitter,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -245,18 +251,40 @@ def test_platform_notional_denies() -> None:
 # ---- Pipeline-denied reservation is released, not leaked ------------------
 
 
-def test_late_stage_denial_releases_capital_reservation() -> None:
-    """HEALTH/PLATFORM denial after CAPITAL allows must release the reservation.
+class _OutboundStub:
+    """Captures `send_command` / `send_abort` for the action_submitter.
 
-    Codex post-auditor-1 P1: CAPITAL is stage 4 of 6, so a HEALTH or
-    PLATFORM_LIMITS denial that fires AFTER CAPITAL would carry the
-    reservation forward in the denied decision. Without explicit
-    release, available capital leaks per-denial. The fix lives in
-    `_submit_translated`: on a denied decision with `reservation
-    is not None`, call `capital_controller.release_reservation`.
-    This test exercises the full path: build pipeline → drive an ENTER
-    that CAPITAL allows → HEALTH denies → confirm controller's
-    `reservation_notional` is back to zero.
+    The release-leak test drives the production `submit` end-to-end;
+    we never expect a command to reach the outbound when HEALTH denies,
+    but we keep the fields populated to satisfy the protocol.
+    """
+
+    def __init__(self) -> None:
+        self.commands: list[object] = []
+        self.aborts: list[object] = []
+
+    def send_command(self, cmd: object) -> str:
+        self.commands.append(cmd)
+        import uuid
+        return str(uuid.uuid4())
+
+    def send_abort(self, **kwargs: object) -> None:
+        self.aborts.append(kwargs)
+
+
+def test_late_stage_denial_releases_capital_reservation() -> None:
+    """HEALTH denial after CAPITAL allows must release the reservation.
+
+    End-to-end through the production action_submitter: build pipeline
+    + controller, wire SubmitterBindings exactly the way the launcher
+    does, drive a BUY ENTER that CAPITAL allows but HEALTH denies, and
+    assert that `capital_state.reservation_notional` is back to zero.
+
+    Deleting the release block at `action_submitter.py::_submit_translated`
+    must fail this test. CAPITAL is stage 4 of 6, so a HEALTH or
+    PLATFORM_LIMITS denial that fires AFTER CAPITAL carries the
+    reservation forward in the denied decision; without explicit
+    release, available capital would leak per-denial.
     """
     cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
     policy = HealthStagePolicy(
@@ -274,29 +302,39 @@ def test_late_stage_denial_releases_capital_reservation() -> None:
         nexus_config=cfg, capital_pool=Decimal('100000'),
         health_policy=policy, health_snapshot_provider=hot_snapshot,
     )
-    ctx = _ctx(
-        command_id='cmd-leak-1', nexus_config=cfg,
-        capital_state=capital_state,
+    outbound = _OutboundStub()
+    submit = build_action_submitter(SubmitterBindings(
+        nexus_config=cfg,
+        state=InstanceState(capital=capital_state),
+        praxis_outbound=cast(PraxisOutbound, outbound),
+        validation_pipeline=pipeline,
+        capital_controller=controller,
+        strategy_budget=Decimal('100000'),
+    ))
+    action = Action(
+        action_type=ActionType.ENTER,
+        direction=OrderSide.BUY,
+        size=Decimal('0.001'),
+        execution_mode=ExecutionMode.SINGLE_SHOT,
+        order_type=OrderType.MARKET,
+        execution_params={'symbol': 'BTCUSDT', 'stop_price': '49750'},
+        deadline=60,
+        trade_id=None,
+        command_id='cmd-action-submit-release',
+        maker_preference=None,
+        reference_price=Decimal('50000'),
     )
-    decision = pipeline.validate(ctx)
-    # The pipeline returns a denied decision carrying the CAPITAL
-    # reservation forward. The action_submitter will release it; we
-    # simulate that here by calling the controller directly.
-    assert not decision.allowed
-    assert decision.failed_stage == ValidationStage.HEALTH
-    assert decision.reservation is not None, (
-        'CAPITAL ran before HEALTH and should have produced a reservation'
+    submit([action], 'long_on_signal')
+    # HEALTH denied → no command reached Praxis.
+    assert len(outbound.commands) == 0
+    # ...AND the CAPITAL-stage reservation was released.
+    # (Removing the release block in _submit_translated would leave
+    # reservation_notional > 0 here.)
+    assert capital_state.reservation_notional == Decimal('0'), (
+        f'reservation leaked: notional={capital_state.reservation_notional} — '
+        'the action_submitter did not release the CAPITAL reservation '
+        'attached to the HEALTH-denied decision.'
     )
-    # Pre-release: reservation_notional > 0 (the leak shape).
-    assert capital_state.reservation_notional > Decimal('0')
-    release_result = controller.release_reservation(
-        decision.reservation.reservation_id,
-    )
-    assert release_result.success, (
-        f'release_reservation failed: {release_result.reason}'
-    )
-    # Post-release: reservation_notional back to zero — capital not leaked.
-    assert capital_state.reservation_notional == Decimal('0')
 
 
 # ---- SELL fast-path divergence is documented in source --------------------

--- a/tests/honesty/test_validation_parity.py
+++ b/tests/honesty/test_validation_parity.py
@@ -242,6 +242,63 @@ def test_platform_notional_denies() -> None:
     assert decision.reason_code.startswith('PLATFORM_LIMITS_MAX_ORDER_NOTIONAL')
 
 
+# ---- Pipeline-denied reservation is released, not leaked ------------------
+
+
+def test_late_stage_denial_releases_capital_reservation() -> None:
+    """HEALTH/PLATFORM denial after CAPITAL allows must release the reservation.
+
+    Codex post-auditor-1 P1: CAPITAL is stage 4 of 6, so a HEALTH or
+    PLATFORM_LIMITS denial that fires AFTER CAPITAL would carry the
+    reservation forward in the denied decision. Without explicit
+    release, available capital leaks per-denial. The fix lives in
+    `_submit_translated`: on a denied decision with `reservation
+    is not None`, call `capital_controller.release_reservation`.
+    This test exercises the full path: build pipeline → drive an ENTER
+    that CAPITAL allows → HEALTH denies → confirm controller's
+    `reservation_notional` is back to zero.
+    """
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    policy = HealthStagePolicy(
+        latency_ms=HealthMetricThresholds(breach=Decimal('10')),
+    )
+
+    def hot_snapshot() -> HealthStageSnapshot:
+        return HealthStageSnapshot(
+            latency_ms=Decimal('100'), consecutive_failures=Decimal('0'),
+            failure_rate=Decimal('0'), rate_limit_headroom=Decimal('1'),
+            clock_drift_ms=Decimal('0'),
+        )
+
+    pipeline, controller, capital_state = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+        health_policy=policy, health_snapshot_provider=hot_snapshot,
+    )
+    ctx = _ctx(
+        command_id='cmd-leak-1', nexus_config=cfg,
+        capital_state=capital_state,
+    )
+    decision = pipeline.validate(ctx)
+    # The pipeline returns a denied decision carrying the CAPITAL
+    # reservation forward. The action_submitter will release it; we
+    # simulate that here by calling the controller directly.
+    assert not decision.allowed
+    assert decision.failed_stage == ValidationStage.HEALTH
+    assert decision.reservation is not None, (
+        'CAPITAL ran before HEALTH and should have produced a reservation'
+    )
+    # Pre-release: reservation_notional > 0 (the leak shape).
+    assert capital_state.reservation_notional > Decimal('0')
+    release_result = controller.release_reservation(
+        decision.reservation.reservation_id,
+    )
+    assert release_result.success, (
+        f'release_reservation failed: {release_result.reason}'
+    )
+    # Post-release: reservation_notional back to zero — capital not leaked.
+    assert capital_state.reservation_notional == Decimal('0')
+
+
 # ---- SELL fast-path divergence is documented in source --------------------
 
 

--- a/tests/honesty/test_validation_parity.py
+++ b/tests/honesty/test_validation_parity.py
@@ -337,6 +337,80 @@ def test_late_stage_denial_releases_capital_reservation() -> None:
     )
 
 
+# ---- Fail-loud on release_reservation failure -----------------------------
+
+
+def test_release_reservation_failure_fails_loud() -> None:
+    """`release_reservation` returning success=False raises RuntimeError.
+
+    Bit-mis no-defects-conviction P1: the reservation being released
+    was just minted by the same `pipeline.validate()` call on the same
+    controller, so any non-success means a wiring/state bug — not an
+    expected race. Mirrors `CapitalLifecycleTracker.record_rejection`'s
+    raise-on-failure pattern. Letting the bug through with a warning
+    would silently re-introduce the leak the branch exists to prevent.
+    """
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    policy = HealthStagePolicy(
+        latency_ms=HealthMetricThresholds(breach=Decimal('10')),
+    )
+
+    def hot_snapshot() -> HealthStageSnapshot:
+        return HealthStageSnapshot(
+            latency_ms=Decimal('100'), consecutive_failures=Decimal('0'),
+            failure_rate=Decimal('0'), rate_limit_headroom=Decimal('1'),
+            clock_drift_ms=Decimal('0'),
+        )
+
+    pipeline, controller, capital_state = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+        health_policy=policy, health_snapshot_provider=hot_snapshot,
+    )
+
+    # Wrap the real controller so `release_reservation` returns a
+    # success=False LifecycleResult — simulating the wiring bug
+    # bit-mis flagged. Every other method delegates to the real one
+    # so the pipeline's CAPITAL stage still produces a real reservation.
+    class _FailingReleaseController:
+        def __init__(self, real: object) -> None:
+            self._real = real
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(self._real, name)
+
+        def release_reservation(self, _reservation_id: str) -> object:
+            from nexus.core.capital_controller.capital_controller import (
+                LifecycleResult,
+            )
+            return LifecycleResult(
+                success=False, reason='simulated-wiring-bug',
+                category=None,
+            )
+
+    failing_controller = _FailingReleaseController(controller)
+    outbound = _OutboundStub()
+    submit = build_action_submitter(SubmitterBindings(
+        nexus_config=cfg,
+        state=InstanceState(capital=capital_state),
+        praxis_outbound=cast(PraxisOutbound, outbound),
+        validation_pipeline=pipeline,
+        capital_controller=cast(object, failing_controller),  # type: ignore[arg-type]
+        strategy_budget=Decimal('100000'),
+    ))
+    action = Action(
+        action_type=ActionType.ENTER, direction=OrderSide.BUY,
+        size=Decimal('0.001'), execution_mode=ExecutionMode.SINGLE_SHOT,
+        order_type=OrderType.MARKET,
+        execution_params={'symbol': 'BTCUSDT', 'stop_price': '49750'},
+        deadline=60, trade_id=None,
+        command_id='cmd-fail-loud',
+        maker_preference=None, reference_price=Decimal('50000'),
+    )
+    import pytest
+    with pytest.raises(RuntimeError, match='pipeline-denied reservation release failed'):
+        submit([action], 'long_on_signal')
+
+
 # ---- SELL fast-path divergence is documented in source --------------------
 
 

--- a/tests/honesty/test_validation_parity.py
+++ b/tests/honesty/test_validation_parity.py
@@ -1,0 +1,282 @@
+"""Slice #28 validator-parity tests.
+
+Every Nexus pipeline stage runs a real `validate_*_stage` call; no
+`_allow_stage` stubs remain. Each per-stage denial test triggers the
+real upstream behavior end-to-end through the pipeline by passing
+config / limits / snapshot providers — the same dials Praxis exposes
+for paper-trade validator tuning.
+"""
+from __future__ import annotations
+
+import ast
+from decimal import Decimal
+from pathlib import Path
+
+from nexus.core.domain.capital_state import CapitalState
+from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.instance_state import InstanceState
+from nexus.core.domain.risk_state import RiskState
+from nexus.core.validator.health_stage import (
+    HealthMetricThresholds,
+    HealthStagePolicy,
+    HealthStageSnapshot,
+)
+from nexus.core.validator.pipeline_models import (
+    ValidationAction,
+    ValidationRequestContext,
+    ValidationStage,
+)
+from nexus.core.validator.platform_limits_stage import (
+    PlatformLimitsStageLimits,
+)
+from nexus.core.validator.price_stage import PriceCheckSnapshot
+from nexus.core.validator.risk_stage import RiskStageLimits
+from nexus.instance_config import InstanceConfig
+
+from backtest_simulator.honesty import build_validation_pipeline
+from backtest_simulator.launcher.action_submitter import (
+    _check_atr_sanity,
+    _check_declared_stop,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CAPITAL_PY = REPO_ROOT / 'backtest_simulator' / 'honesty' / 'capital.py'
+
+_PARITY_DIVERGENCE_PHRASE = 'supplementing the real Nexus INTAKE stage'
+
+
+def _ctx(
+    *,
+    command_id: str,
+    notional: Decimal = Decimal('1000'),
+    fees: Decimal = Decimal('2'),
+    budget: Decimal = Decimal('100000'),
+    action: ValidationAction = ValidationAction.ENTER,
+    side: OrderSide = OrderSide.BUY,
+    nexus_config: InstanceConfig | None = None,
+    risk_state: RiskState | None = None,
+    capital_state: CapitalState | None = None,
+) -> ValidationRequestContext:
+    state = InstanceState(
+        capital=(
+            capital_state if capital_state is not None
+            else CapitalState(capital_pool=budget)
+        ),
+        risk=risk_state if risk_state is not None else RiskState(),
+    )
+    return ValidationRequestContext(
+        strategy_id='bts',
+        order_notional=notional,
+        estimated_fees=fees,
+        strategy_budget=budget,
+        state=state,
+        config=nexus_config or InstanceConfig(
+            account_id='bts-test', venue='binance_spot_simulated',
+        ),
+        action=action,
+        symbol='BTCUSDT',
+        order_side=side,
+        order_size=Decimal('0.01'),
+        trade_id='trade-1',
+        command_id=command_id,
+        current_order_notional=None,
+    )
+
+
+# ---- core parity proofs ----------------------------------------------------
+
+
+def test_no_allow_stage_in_source() -> None:
+    """`_allow_stage` is gone from `capital.py`. AST + grep-clean."""
+    src = CAPITAL_PY.read_text(encoding='utf-8')
+    tree = ast.parse(src)
+    fn_names = {n.name for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)}
+    assert '_allow_stage' not in fn_names, (
+        '`_allow_stage` must not be defined in capital.py — its presence '
+        'proves the validator wiring regressed back to stubs.'
+    )
+    assert '_allow_stage' not in src, (
+        '`_allow_stage` must not appear anywhere in capital.py source '
+        '(definition, reference, comment, or docstring).'
+    )
+
+
+def test_all_stages_run_real_validators() -> None:
+    """Every pipeline stage binds to a non-`_allow_stage` callable."""
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    pipeline, _ctrl, _state = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+    )
+    for stage in pipeline.stage_order:
+        validator = pipeline._validators[stage]
+        qualname = validator.__qualname__
+        assert '_allow_stage' not in qualname, (
+            f'{stage.name} validator `{qualname}` is the `_allow_stage` stub'
+        )
+    # Capture the full set of stages so a future PR that drops one fails
+    # both this test and the pipeline's own `_validate_validators` check.
+    assert set(pipeline.stage_order) == {
+        ValidationStage.INTAKE, ValidationStage.RISK, ValidationStage.PRICE,
+        ValidationStage.CAPITAL, ValidationStage.HEALTH,
+        ValidationStage.PLATFORM_LIMITS,
+    }
+
+
+# ---- per-stage end-to-end denials ------------------------------------------
+
+
+def test_intake_max_order_rate_denies() -> None:
+    """INTAKE: `max_order_rate=1` denies the second ENTER inside one second."""
+    cfg = InstanceConfig(
+        account_id='bts-test', venue='binance_spot_simulated',
+        max_order_rate=1,
+    )
+    pipeline, _, _ = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+    )
+    d1 = pipeline.validate(_ctx(command_id='cmd-rate-1', nexus_config=cfg))
+    d2 = pipeline.validate(_ctx(command_id='cmd-rate-2', nexus_config=cfg))
+    assert d1.allowed
+    assert not d2.allowed
+    assert d2.failed_stage == ValidationStage.INTAKE
+    assert d2.reason_code == 'INTAKE_MAX_ORDER_RATE_EXCEEDED'
+
+
+def test_intake_duplicate_command_id_denies() -> None:
+    """INTAKE: same command_id within the duplicate window denies."""
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    pipeline, _, _ = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+    )
+    ctx_a = _ctx(command_id='cmd-dup-1', nexus_config=cfg)
+    ctx_b = _ctx(command_id='cmd-dup-1', nexus_config=cfg)
+    d1 = pipeline.validate(ctx_a)
+    d2 = pipeline.validate(ctx_b)
+    assert d1.allowed
+    assert not d2.allowed
+    assert d2.failed_stage == ValidationStage.INTAKE
+    assert d2.reason_code == 'INTAKE_DUPLICATE_ORDER_WINDOW'
+
+
+def test_price_spread_denies() -> None:
+    """PRICE: snapshot spread above `max_spread_bps` denies."""
+    cfg = InstanceConfig(
+        account_id='bts-test', venue='binance_spot_simulated',
+        max_spread_bps=Decimal('5'),
+    )
+
+    def wide_spread() -> PriceCheckSnapshot | None:
+        return PriceCheckSnapshot(spread_bps=Decimal('50'))
+
+    pipeline, _, _ = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+        price_snapshot_provider=wide_spread,
+    )
+    decision = pipeline.validate(_ctx(command_id='cmd-price', nexus_config=cfg))
+    assert not decision.allowed
+    assert decision.failed_stage == ValidationStage.PRICE
+    assert decision.reason_code == 'PRICE_SPREAD_LIMIT'
+
+
+def test_risk_drawdown_denies() -> None:
+    """RISK: total_drawdown above `max_total_drawdown` denies."""
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    pipeline, _, _ = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+        risk_limits=RiskStageLimits(max_total_drawdown=Decimal('100')),
+    )
+    risk = RiskState()
+    risk.total_drawdown = Decimal('200')
+    ctx = _ctx(command_id='cmd-risk', nexus_config=cfg, risk_state=risk)
+    # Re-bind context.state.risk because pipeline reads context.state.risk
+    # not its own state. Replace the ctx.state with one that already has
+    # the breached drawdown.
+    decision = pipeline.validate(ctx)
+    assert not decision.allowed
+    assert decision.failed_stage == ValidationStage.RISK
+    assert decision.reason_code == 'RISK_TOTAL_DRAWDOWN_LIMIT'
+
+
+def test_health_latency_denies() -> None:
+    """HEALTH: snapshot latency above breach threshold denies."""
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    policy = HealthStagePolicy(
+        latency_ms=HealthMetricThresholds(breach=Decimal('10')),
+    )
+
+    def hot_snapshot() -> HealthStageSnapshot:
+        return HealthStageSnapshot(
+            latency_ms=Decimal('100'),
+            consecutive_failures=Decimal('0'),
+            failure_rate=Decimal('0'),
+            rate_limit_headroom=Decimal('1'),
+            clock_drift_ms=Decimal('0'),
+        )
+
+    pipeline, _, _ = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+        health_policy=policy,
+        health_snapshot_provider=hot_snapshot,
+    )
+    decision = pipeline.validate(_ctx(command_id='cmd-health', nexus_config=cfg))
+    assert not decision.allowed
+    assert decision.failed_stage == ValidationStage.HEALTH
+    assert decision.reason_code == 'HEALTH_LATENCY_BREACH'
+
+
+def test_platform_notional_denies() -> None:
+    """PLATFORM_LIMITS: order_notional above `max_order_notional` denies."""
+    cfg = InstanceConfig(account_id='bts-test', venue='binance_spot_simulated')
+    pipeline, _, _ = build_validation_pipeline(
+        nexus_config=cfg, capital_pool=Decimal('100000'),
+        platform_limits=PlatformLimitsStageLimits(
+            max_order_notional=Decimal('100'),
+        ),
+    )
+    ctx = _ctx(
+        command_id='cmd-platform', notional=Decimal('1000'), nexus_config=cfg,
+    )
+    decision = pipeline.validate(ctx)
+    assert not decision.allowed
+    assert decision.failed_stage == ValidationStage.PLATFORM_LIMITS
+    assert decision.reason_code.startswith('PLATFORM_LIMITS_MAX_ORDER_NOTIONAL')
+
+
+# ---- SELL fast-path divergence is documented in source --------------------
+
+
+def test_sell_fast_path_documented_in_source() -> None:
+    """The bts-only SELL fast-path's bypass reasons are visible in source.
+
+    Slice #28 deliberately leaves the SELL close path bypassing
+    `validation_pipeline.validate` because (a) the long-only strategy
+    template does not propagate `Action.trade_id` from BUY to SELL, so
+    Nexus's `make_reference_integrity_hook` would deny every close on
+    `INTAKE_TRADE_REFERENCE_INVALID`, and (b) `CapitalController` has
+    no `close_position` primitive. Both follow-ups are upstream
+    Nexus/strategy work tracked at slice merge. The divergence stays
+    explicit in the source comment so a future reviewer sees the
+    debt rather than an unexplained `if action.direction == OrderSide.SELL:`.
+    """
+    submitter_src = (
+        Path(__file__).resolve().parents[2]
+        / 'backtest_simulator' / 'launcher' / 'action_submitter.py'
+    ).read_text(encoding='utf-8')
+    assert 'pipeline bypassed' in submitter_src
+    for marker in ('trade_id', 'close_position'):
+        assert marker in submitter_src
+
+
+# ---- INTAKE pre-hook divergence is documented, not hidden -----------------
+
+
+def test_intake_pre_hook_docstring_documents_divergence() -> None:
+    """Both pre-hooks cite the parity-divergence phrase in their docstring."""
+    declared_doc = _check_declared_stop.__doc__ or ''
+    atr_doc = _check_atr_sanity.__doc__ or ''
+    assert _PARITY_DIVERGENCE_PHRASE in declared_doc, (
+        '_check_declared_stop docstring must cite the divergence phrase'
+    )
+    assert _PARITY_DIVERGENCE_PHRASE in atr_doc, (
+        '_check_atr_sanity docstring must cite the divergence phrase'
+    )

--- a/tests/launcher/test_action_submitter.py
+++ b/tests/launcher/test_action_submitter.py
@@ -67,6 +67,7 @@ def _pipeline_and_state() -> tuple[ValidationPipeline, InstanceState]:
     # the InstanceState carries — that's the invariant the real
     # launcher enforces and what the CAPITAL validator reads from.
     pipeline, _controller, capital_state = build_validation_pipeline(
+        nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     state = InstanceState(capital=capital_state)

--- a/tests/launcher/test_action_submitter.py
+++ b/tests/launcher/test_action_submitter.py
@@ -9,6 +9,7 @@ from decimal import Decimal
 from typing import cast
 
 import pytest
+from nexus.core.capital_controller.capital_controller import CapitalController
 from nexus.core.domain.enums import OrderSide
 from nexus.core.domain.order_types import ExecutionMode, OrderType
 from nexus.core.validator import ValidationPipeline
@@ -52,26 +53,28 @@ def _nexus_config() -> NexusInstanceConfig:
 def _make_bindings(
     outbound: _OutboundStub,
     pipeline: ValidationPipeline,
+    controller: CapitalController,
     state: InstanceState,
 ) -> SubmitterBindings:
     return SubmitterBindings(
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
     )
 
 
-def _pipeline_and_state() -> tuple[ValidationPipeline, InstanceState]:
+def _pipeline_and_state() -> tuple[ValidationPipeline, CapitalController, InstanceState]:
     # Build a Part 2-shaped pipeline that shares the same CapitalState
     # the InstanceState carries — that's the invariant the real
     # launcher enforces and what the CAPITAL validator reads from.
-    pipeline, _controller, capital_state = build_validation_pipeline(
+    pipeline, controller, capital_state = build_validation_pipeline(
         nexus_config=NexusInstanceConfig(account_id='bts-test', venue='binance_spot_simulated'),
         capital_pool=Decimal('100000'),
     )
     state = InstanceState(capital=capital_state)
-    return pipeline, state
+    return pipeline, controller, state
 
 
 def _enter_action() -> Action:
@@ -114,15 +117,15 @@ def _sell_action() -> Action:
 
 def test_builder_returns_callable() -> None:
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    submit = build_action_submitter(_make_bindings(outbound, pipeline, state))
+    pipeline, controller, state = _pipeline_and_state()
+    submit = build_action_submitter(_make_bindings(outbound, pipeline, controller, state))
     assert callable(submit)
 
 
 def test_enter_with_declared_stop_passes_validation_and_sends() -> None:
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    submit = build_action_submitter(_make_bindings(outbound, pipeline, state))
+    pipeline, controller, state = _pipeline_and_state()
+    submit = build_action_submitter(_make_bindings(outbound, pipeline, controller, state))
     submit([_enter_action()], 'long_on_signal')
     assert len(outbound.commands) == 1
     cmd = outbound.commands[0]
@@ -137,8 +140,8 @@ def test_enter_with_declared_stop_passes_validation_and_sends() -> None:
 def test_buy_entry_without_declared_stop_is_rejected_by_intake() -> None:
     # Part 2 INTAKE gate — no stop, no entry.
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    submit = build_action_submitter(_make_bindings(outbound, pipeline, state))
+    pipeline, controller, state = _pipeline_and_state()
+    submit = build_action_submitter(_make_bindings(outbound, pipeline, controller, state))
     action_no_stop = Action(
         action_type=ActionType.ENTER,
         direction=OrderSide.BUY,
@@ -159,8 +162,8 @@ def test_sell_exit_without_stop_is_accepted() -> None:
     # Long-only convention — SELL closes an existing long and is itself
     # the risk close, so no stop_price is required.
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    submit = build_action_submitter(_make_bindings(outbound, pipeline, state))
+    pipeline, controller, state = _pipeline_and_state()
+    submit = build_action_submitter(_make_bindings(outbound, pipeline, controller, state))
     submit([_sell_action()], 'long_on_signal')
     assert len(outbound.commands) == 1
     # `_to_praxis_enums` converts side to Praxis OrderSide; compare by name.
@@ -169,8 +172,8 @@ def test_sell_exit_without_stop_is_accepted() -> None:
 
 def test_abort_action_routed_to_send_abort() -> None:
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    submit = build_action_submitter(_make_bindings(outbound, pipeline, state))
+    pipeline, controller, state = _pipeline_and_state()
+    submit = build_action_submitter(_make_bindings(outbound, pipeline, controller, state))
     abort = Action(
         action_type=ActionType.ABORT,
         direction=None, size=None, execution_mode=None, order_type=None,
@@ -194,8 +197,8 @@ def test_submission_propagates_per_action_errors() -> None:
         def send_command(self, cmd: object) -> str:
             raise RuntimeError('injected')
     outbound = _RaisingOutbound()
-    pipeline, state = _pipeline_and_state()
-    submit = build_action_submitter(_make_bindings(outbound, pipeline, state))
+    pipeline, controller, state = _pipeline_and_state()
+    submit = build_action_submitter(_make_bindings(outbound, pipeline, controller, state))
     with pytest.raises(RuntimeError, match='injected'):
         submit([_enter_action()], 'long_on_signal')
     # No command got through; the capture happens inside the outbound
@@ -210,7 +213,7 @@ def test_on_reservation_hook_receives_decision_with_reservation() -> None:
     # decision to carry a `reservation` so downstream send_order/ack
     # calls can reference it.
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     captured: list[tuple[str, object, object, Action]] = []
 
     def on_reservation(
@@ -219,7 +222,7 @@ def test_on_reservation_hook_receives_decision_with_reservation() -> None:
         captured.append((command_id, decision, context, action))
 
     submit = build_action_submitter(
-        _make_bindings(outbound, pipeline, state),
+        _make_bindings(outbound, pipeline, controller, state),
         on_reservation=on_reservation,
     )
     submit([_enter_action()], 'long_on_signal')
@@ -237,10 +240,10 @@ def test_on_submit_hook_fires_with_command_id() -> None:
     # `submitted_commands` counter for the synchronous drain. It
     # must fire exactly once per action that reached Praxis.
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     submitted: list[str] = []
     submit = build_action_submitter(
-        _make_bindings(outbound, pipeline, state),
+        _make_bindings(outbound, pipeline, controller, state),
         on_submit=submitted.append,
     )
     submit([_enter_action(), _sell_action()], 'long_on_signal')
@@ -258,11 +261,12 @@ def test_maybe_refresh_limit_to_touch_buy_biases_below() -> None:
     instead of the touch-biased `49999.99`.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     bindings = SubmitterBindings(
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
         touch_provider=lambda _sym: Decimal('50000'),
         tick_provider=lambda _sym: Decimal('0.01'),
@@ -303,11 +307,12 @@ def test_maybe_refresh_limit_to_touch_buy_biases_below() -> None:
 def test_maybe_refresh_limit_to_touch_sell_biases_above() -> None:
     """LIMIT SELL action's price gets rewritten to `touch + tick`."""
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     bindings = SubmitterBindings(
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
         touch_provider=lambda _sym: Decimal('50000'),
         tick_provider=lambda _sym: Decimal('0.01'),
@@ -337,6 +342,7 @@ def test_maybe_refresh_limit_to_touch_sell_biases_above() -> None:
 def _atr_bindings(
     outbound: _OutboundStub,
     pipeline: ValidationPipeline,
+    controller: CapitalController,
     state: InstanceState,
     *,
     atr: Decimal | None = Decimal('300'),
@@ -357,6 +363,7 @@ def _atr_bindings(
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
         atr_gate=gate, atr_provider=_provider,
     )
@@ -374,8 +381,8 @@ def test_atr_sanity_rejects_tight_stop_buy_entry() -> None:
     let the command flow to outbound and break this test.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    bindings = _atr_bindings(outbound, pipeline, state)
+    pipeline, controller, state = _pipeline_and_state()
+    bindings = _atr_bindings(outbound, pipeline, controller, state)
     rejected: list[ValidationDecision] = []
     submit = build_action_submitter(
         bindings,
@@ -409,8 +416,8 @@ def test_atr_sanity_allows_sane_stop_buy_entry() -> None:
     shape on BTCUSDT, so production runs do NOT trigger the gate.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    bindings = _atr_bindings(outbound, pipeline, state)
+    pipeline, controller, state = _pipeline_and_state()
+    bindings = _atr_bindings(outbound, pipeline, controller, state)
     rejected: list[ValidationDecision] = []
     submit = build_action_submitter(
         bindings,
@@ -433,8 +440,8 @@ def test_atr_sanity_uncalibrated_denies() -> None:
     can tell warm-up gaps apart from gameability rejections.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    bindings = _atr_bindings(outbound, pipeline, state, atr=None)
+    pipeline, controller, state = _pipeline_and_state()
+    bindings = _atr_bindings(outbound, pipeline, controller, state, atr=None)
     rejected: list[ValidationDecision] = []
     submit = build_action_submitter(
         bindings,
@@ -464,8 +471,8 @@ def test_atr_sanity_uses_limit_price_over_seed_for_entry() -> None:
     order; this test would fail.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    bindings = _atr_bindings(outbound, pipeline, state)
+    pipeline, controller, state = _pipeline_and_state()
+    bindings = _atr_bindings(outbound, pipeline, controller, state)
     rejected: list[ValidationDecision] = []
     submit = build_action_submitter(
         bindings,
@@ -508,7 +515,7 @@ def test_atr_sanity_uses_touch_provider_when_available() -> None:
     `reference_price` and ALLOWS the order; this test would fail.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     rejected: list[ValidationDecision] = []
     from backtest_simulator.honesty.atr import AtrSanityGate
     gate = AtrSanityGate(atr_window_seconds=300, k=Decimal('0.5'))
@@ -522,6 +529,7 @@ def test_atr_sanity_uses_touch_provider_when_available() -> None:
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
         touch_provider=_touch,
         atr_gate=gate, atr_provider=_atr,
@@ -564,7 +572,7 @@ def test_atr_sanity_k_zero_disables_gate_even_on_uncalibrated() -> None:
     uncalibrated path and `n_rejected/uncal` rises.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     rejected: list[ValidationDecision] = []
     from backtest_simulator.honesty.atr import AtrSanityGate
     gate = AtrSanityGate(atr_window_seconds=300, k=Decimal('0'))
@@ -575,6 +583,7 @@ def test_atr_sanity_k_zero_disables_gate_even_on_uncalibrated() -> None:
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
         atr_gate=gate, atr_provider=_atr_returns_none,
     )
@@ -600,8 +609,8 @@ def test_atr_sanity_skips_sell_exit() -> None:
     long; gating it would leave the strategy holding risk.
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
-    bindings = _atr_bindings(outbound, pipeline, state)
+    pipeline, controller, state = _pipeline_and_state()
+    bindings = _atr_bindings(outbound, pipeline, controller, state)
     rejected: list[ValidationDecision] = []
     submit = build_action_submitter(
         bindings,
@@ -626,7 +635,7 @@ def test_maybe_refresh_limit_to_touch_skips_market_orders() -> None:
     Praxis SingleShotParams).
     """
     outbound = _OutboundStub()
-    pipeline, state = _pipeline_and_state()
+    pipeline, controller, state = _pipeline_and_state()
     refresh_calls: list[str] = []
 
     def _spying_touch(symbol: str) -> Decimal | None:
@@ -637,6 +646,7 @@ def test_maybe_refresh_limit_to_touch_skips_market_orders() -> None:
         nexus_config=_nexus_config(), state=state,
         praxis_outbound=cast(PraxisOutbound, outbound),
         validation_pipeline=pipeline,
+        capital_controller=controller,
         strategy_budget=Decimal('100000'),
         touch_provider=_spying_touch,
         tick_provider=lambda _sym: Decimal('0.01'),

--- a/tests/tools/test_lint_ci_contract.py
+++ b/tests/tools/test_lint_ci_contract.py
@@ -72,6 +72,11 @@ EXPECTED_RUFF_POLICY: Final[dict[str, object]] = {
         # signature exactly so it can replace the adapter's method
         # via setattr without breaking the Protocol.
         'backtest_simulator/launcher/launcher.py': ['PLR0913'],
+        # Slice #28: build_validation_pipeline mirrors Praxis's
+        # _build_validation_pipeline parameter shape. The 9 kwargs are
+        # the parity surface; collapsing them would diverge from
+        # Praxis and lose per-stage knob clarity.
+        'backtest_simulator/honesty/capital.py': ['PLR0913'],
         # M2 Task 1 (slice #17): the CLI subcommand modules
         # legitimately print() per-run summaries to stdout (the
         # operator's debug surface) and the sweep / run / pipeline


### PR DESCRIPTION
## Summary

Closes #28. Replaces five `_allow_stage` stubs in `backtest_simulator/honesty/capital.py::build_validation_pipeline` with real Nexus `validate_*_stage` calls, mirroring the Praxis paper-trade reference at `praxis/launcher.py::_build_validation_pipeline`. MMVP-lenient defaults preserve existing test pass-through; operator-supplied `nexus_config` / limits / snapshot providers dial in real denial behavior.

- **INTAKE / RISK / PRICE / HEALTH / PLATFORM_LIMITS** now run real validators (CAPITAL was already real).
- **Late-stage denial leak fixed**: HEALTH/PLATFORM denials carry the CAPITAL reservation forward; `_submit_translated` now releases it via `bindings.capital_controller.release_reservation` so available capital is not silently leaked.
- **SELL fast-path stays bypassed** as documented divergence with two upstream debt items (long-only strategy template doesn't propagate `Action.trade_id`; `CapitalController` has no `close_position` primitive).
- **Pre-hooks remain bts-side** (`_check_declared_stop`, `_check_atr_sanity`) — `ValidationRequestContext` does not carry `execution_params['stop_price']`. Docstrings rewritten to cite the parity-divergence phrase + closure path.

11 tests in `tests/honesty/test_validation_parity.py` lock the contract.

## Budget raises

[budget-raise: backtest_simulator/honesty/capital.py: real Nexus stage closures + lenient-default factories + parity-mirroring snapshot providers — Praxis equivalent runs ~150 lines]
[budget-raise: backtest_simulator/launcher/action_submitter.py: SubmitterBindings gains capital_controller; denied-decision release path adds ~12 lines; pre-hook docstrings carry parity-divergence note]

## Test plan

- [x] `pytest tests/honesty/test_validation_parity.py -q` — 11 passed
- [x] `pytest -q` — 426 passed
- [x] `python -m backtest_simulator.cli gate lint` — All checks passed!
- [x] All 4 bloat gates pass locally
- [x] codex post-auditor-1 P1 (capital reservation leak) addressed
- [ ] codex post-auditor-2 verdict (in flight)
- [ ] zero-bang review

🤖 Generated with [Claude Code](https://claude.com/claude-code)