### PR TITLE
fix(strategy): force-flatten open positions at window close

### DIFF
--- a/.github/module_budgets.json
+++ b/.github/module_budgets.json
@@ -40,7 +40,7 @@
   "backtest_simulator/pipeline/manifest_builder.py": 240,
   "backtest_simulator/pipeline/bundle.py": 320,
   "backtest_simulator/pipeline/_strategy_templates/__init__.py": 10,
-  "backtest_simulator/pipeline/_strategy_templates/long_on_signal.py": 275,
+  "backtest_simulator/pipeline/_strategy_templates/long_on_signal.py": 295,
   "backtest_simulator/strategies/__init__.py": 30,
   "backtest_simulator/strategies/buy_and_hold.py": 160,
   "backtest_simulator/strategies/inverse_prescient.py": 200,

--- a/.github/module_budgets.json
+++ b/.github/module_budgets.json
@@ -40,7 +40,7 @@
   "backtest_simulator/pipeline/manifest_builder.py": 240,
   "backtest_simulator/pipeline/bundle.py": 320,
   "backtest_simulator/pipeline/_strategy_templates/__init__.py": 10,
-  "backtest_simulator/pipeline/_strategy_templates/long_on_signal.py": 260,
+  "backtest_simulator/pipeline/_strategy_templates/long_on_signal.py": 275,
   "backtest_simulator/strategies/__init__.py": 30,
   "backtest_simulator/strategies/buy_and_hold.py": 160,
   "backtest_simulator/strategies/inverse_prescient.py": 200,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,49 @@
+# v2.2.1
+
+Force-flatten at window close. The `long_on_signal` strategy template
+now refuses to leave inventory open past the window's last in-window
+signal. `StrategyParamsSpec` carries a new `force_flatten_after`
+field which `_run_window.py` sets to `window_end - kline_size`; the
+manifest builder bakes the ISO string into the strategy's
+`_BAKED_CONFIG`, and the strategy's `on_signal` adds a check at the
+top: if the signal's timestamp is at or after the cutoff, it emits
+SELL on any held inventory regardless of `_preds`, and refuses new
+BUYs. The SELL flows through the same Nexus → Praxis → venue
+adapter path every other SELL takes, so the trade ledger,
+EventSpine, and capital state remain naturally consistent — no bts
+launcher / EventSpine / tracker changes.
+
+Without this, a BUY late in the window (or a regime where `_preds=0`
+never fires before window close) opened a position with no closing
+signal before subprocess shutdown, leaving the per-day `trades` summary
+showing `0` while EventSpine carried orphaned BUY events. Downstream
+DSR/SPA/CPCV math consumed that biased return distribution.
+
+`force_flatten_after` must be tz-aware. ManifestBuilder.build raises
+ValueError when a naive datetime is provided; the strategy template
+defensively re-checks the parsed value at on_startup.
+
+Five tests in `tests/pipeline/test_force_flatten_at_window_close.py`
+cover: SELL emitted at the cutoff signal when long, SELL emitted
+after the cutoff when long, no new BUY at-or-after the cutoff when
+flat, no premature flatten before the cutoff, and legacy behaviour
+preserved when `force_flatten_after=None`.
+
+Surfaces:
+- `backtest_simulator/pipeline/manifest_builder.py` — `force_flatten_after`
+  field + bake into `__BTS_PARAMS__` + tz-aware validation
+- `backtest_simulator/pipeline/_strategy_templates/long_on_signal.py`
+  — parse cutoff from baked config, force-flatten branch in
+  `on_signal`, defensive tz-aware check
+- `backtest_simulator/cli/_run_window.py` — set cutoff to
+  `window_end - kline_size`
+- `tests/pipeline/test_force_flatten_at_window_close.py` — new
+- `tests/tools/test_lint_ci_contract.py` — extend ruff per-file-ignores
+  contract for the strategy template
+- `pyproject.toml` — add the strategy template to ruff per-file-ignores
+- `.github/module_budgets.json` — bump strategy template budget for
+  the new defensive check
+
 # v2.2.0
 
 Bts honors bundle `data_source.params` end-to-end and exposes the

--- a/backtest_simulator/cli/_run_window.py
+++ b/backtest_simulator/cli/_run_window.py
@@ -18,7 +18,7 @@ import os
 import shutil
 import subprocess
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import ROUND_DOWN, Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict, cast
@@ -292,6 +292,15 @@ def run_window_in_process(
             kelly_pct=effective_kelly_pct,
             estimated_price=seed_price,
             stop_bps=Decimal('50'),
+            # Force-flatten cutoff = `window_end - kline_size`. The
+            # strategy's last in-window signal arrives at this
+            # timestamp; on or after it, the strategy emits SELL on
+            # any held inventory and refuses new BUYs. Without this
+            # cutoff, a BUY late in the window could open a position
+            # that has no closing signal before subprocess shutdown,
+            # leaving an orphaned position the per-day summary
+            # mislabels as `trades 0`.
+            force_flatten_after=window_end - timedelta(seconds=interval_seconds),
             maker_preference=maker_preference,
         ),
     )

--- a/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
+++ b/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from decimal import ROUND_DOWN, Decimal
 
 from nexus.core.domain.enums import OrderSide
@@ -31,6 +32,7 @@ class _Config:
     def __init__(
         self, symbol: str, capital: Decimal, kelly_pct: Decimal,
         estimated_price: Decimal, stop_bps: Decimal,
+        force_flatten_after: datetime | None,
         maker_preference: bool = False,
     ) -> None:
         self.symbol = symbol
@@ -38,6 +40,14 @@ class _Config:
         self.kelly_pct = kelly_pct
         self.estimated_price = estimated_price
         self.stop_bps = stop_bps
+        # Force-flatten cutoff. When the next signal's timestamp is
+        # at or after this instant, the strategy emits SELL on any
+        # held inventory regardless of `_preds`, AND blocks new BUYs.
+        # bts sets it to `window_end - kline_size` so the strategy's
+        # last in-window signal closes any open position before the
+        # subprocess shuts down. None disables force-flatten (legacy
+        # behaviour: positions can survive past window close).
+        self.force_flatten_after = force_flatten_after
         # When True the strategy emits LIMIT orders at the
         # estimated price (passive maker post). When False
         # (default) it emits MARKET orders. The runtime venue
@@ -75,12 +85,18 @@ class Strategy(_StrategyBase):
         # the mechanism ManifestBuilder uses to carry per-instance config
         # to each strategy file.
         del params, context
+        force_flatten_raw = _BAKED_CONFIG.get('force_flatten_after')
+        force_flatten_after = (
+            None if force_flatten_raw is None
+            else datetime.fromisoformat(str(force_flatten_raw))
+        )
         self._config = _Config(
             symbol=str(_BAKED_CONFIG['symbol']),
             capital=Decimal(str(_BAKED_CONFIG['capital'])),
             kelly_pct=Decimal(str(_BAKED_CONFIG['kelly_pct'])),
             estimated_price=Decimal(str(_BAKED_CONFIG['estimated_price'])),
             stop_bps=Decimal(str(_BAKED_CONFIG['stop_bps'])),
+            force_flatten_after=force_flatten_after,
             maker_preference=bool(
                 _BAKED_CONFIG.get('maker_preference', False),
             ),
@@ -131,6 +147,23 @@ class Strategy(_StrategyBase):
             'on_signal fired: preds=%s probs=%s was_long=%s',
             preds, signal.values.get('_probs'), was_long,
         )
+        # Force-flatten at window close: if this signal arrives at or
+        # after the configured cutoff (window_end - kline_size), close
+        # any open position immediately and refuse new entries. The
+        # strategy's last in-window signal becomes a guaranteed
+        # exposure-zero point so per-day stats reflect realized PnL
+        # without orphaned positions.
+        cutoff = self._config.force_flatten_after
+        if cutoff is not None and signal.timestamp >= cutoff:
+            if was_long and not self._pending_sell:
+                qty = self._entry_qty
+                self._pending_sell = True
+                _log.info(
+                    'FORCE FLATTEN at window close: qty=%s ts=%s cutoff=%s',
+                    qty, signal.timestamp, cutoff,
+                )
+                return [self._build_action(OrderSide.SELL, qty, signal)]
+            return []
         if preds == 1 and not was_long and not self._pending_buy:
             qty_raw = (
                 self._config.capital * self._config.kelly_pct / Decimal('100')

--- a/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
+++ b/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
@@ -91,14 +91,18 @@ class Strategy(_StrategyBase):
             else datetime.fromisoformat(str(force_flatten_raw))
         )
         # Defensive: signal.timestamp is always UTC-aware (Nexus emits
-        # `datetime.now(tz=timezone.utc)`); a naive cutoff raises
-        # TypeError on the comparison. ManifestBuilder validates this
-        # at config build time, but a hand-edited baked config would
-        # bypass that — this catches the runtime side too.
-        if force_flatten_after is not None and force_flatten_after.tzinfo is None:
+        # `datetime.now(tz=timezone.utc)`). An effectively-naive cutoff
+        # raises TypeError on the comparison. ManifestBuilder validates
+        # this at config build time; a hand-edited baked config would
+        # bypass that. utcoffset() catches tzinfo subclasses whose
+        # utcoffset() returns None.
+        if (
+            force_flatten_after is not None
+            and force_flatten_after.utcoffset() is None
+        ):
             msg = (
                 f'_BAKED_CONFIG[force_flatten_after] must be tz-aware, '
-                f'got naive {force_flatten_after!r}'
+                f'got effectively-naive {force_flatten_after!r}'
             )
             raise ValueError(msg)
         self._config = _Config(
@@ -217,7 +221,9 @@ class Strategy(_StrategyBase):
             return [self._build_action(OrderSide.SELL, qty, signal)]
         return []
 
-    def _build_action(self, side: OrderSide, qty: Decimal, signal: Signal) -> Action:
+    def _build_action(
+        self, side: OrderSide, qty: Decimal, signal: Signal | None,
+    ) -> Action:
         del signal
         # Declared-stop enforcement (Part 2): every OPEN-position ENTER
         # must carry a concrete `stop_price`. For long-only we only
@@ -345,6 +351,28 @@ class Strategy(_StrategyBase):
                     outcome.outcome_type.value, outcome.fill_size,
                     self._entry_qty,
                 )
+                # Force-flatten edge case: a maker LIMIT BUY emitted
+                # before the cutoff can fill (via on_outcome) AFTER
+                # the cutoff. on_signal's force-flatten branch won't
+                # see this position because no further signal fires
+                # post-cutoff. Emit the closing SELL here, gated on
+                # the same cutoff check.
+                cutoff = self._config.force_flatten_after
+                if (
+                    cutoff is not None
+                    and outcome.timestamp >= cutoff
+                    and not self._pending_sell
+                ):
+                    qty = self._entry_qty
+                    self._pending_sell = True
+                    _log.info(
+                        'FORCE FLATTEN on BUY fill past cutoff: qty=%s '
+                        'fill_ts=%s cutoff=%s',
+                        qty, outcome.timestamp, cutoff,
+                    )
+                    return [
+                        self._build_action(OrderSide.SELL, qty, signal=None),
+                    ]
             else:
                 # Reduce inventory by the fill_size; only flip
                 # `_long` to False when the SELL has FULLY closed

--- a/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
+++ b/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
@@ -90,6 +90,17 @@ class Strategy(_StrategyBase):
             None if force_flatten_raw is None
             else datetime.fromisoformat(str(force_flatten_raw))
         )
+        # Defensive: signal.timestamp is always UTC-aware (Nexus emits
+        # `datetime.now(tz=timezone.utc)`); a naive cutoff raises
+        # TypeError on the comparison. ManifestBuilder validates this
+        # at config build time, but a hand-edited baked config would
+        # bypass that — this catches the runtime side too.
+        if force_flatten_after is not None and force_flatten_after.tzinfo is None:
+            msg = (
+                f'_BAKED_CONFIG[force_flatten_after] must be tz-aware, '
+                f'got naive {force_flatten_after!r}'
+            )
+            raise ValueError(msg)
         self._config = _Config(
             symbol=str(_BAKED_CONFIG['symbol']),
             capital=Decimal(str(_BAKED_CONFIG['capital'])),

--- a/backtest_simulator/pipeline/manifest_builder.py
+++ b/backtest_simulator/pipeline/manifest_builder.py
@@ -134,12 +134,16 @@ class ManifestBuilder:
         # raise `TypeError: can't compare offset-naive and offset-aware
         # datetimes` on the first signal — fail loud at config build.
         ffa = strategy_params.force_flatten_after
-        if ffa is not None and ffa.tzinfo is None:
+        # `tzinfo is None` is not sufficient: a tzinfo subclass whose
+        # utcoffset() returns None is effectively naive (Python treats
+        # it as such for comparisons). Check utcoffset() to catch both.
+        if ffa is not None and ffa.utcoffset() is None:
             msg = (
                 f'StrategyParamsSpec.force_flatten_after must be '
-                f'tz-aware, got naive datetime {ffa!r}. The strategy '
-                f'compares this against UTC-aware signal timestamps; '
-                f'a naive cutoff raises TypeError on the first signal.'
+                f'tz-aware, got effectively-naive datetime {ffa!r} '
+                f'(tzinfo={ffa.tzinfo!r} but utcoffset()=None). The '
+                f'strategy compares this against UTC-aware signal '
+                f'timestamps; a naive cutoff raises TypeError.'
             )
             raise ValueError(msg)
         raw_params: dict[str, object] = {

--- a/backtest_simulator/pipeline/manifest_builder.py
+++ b/backtest_simulator/pipeline/manifest_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
+from datetime import datetime
 from decimal import Decimal
 from pathlib import Path
 
@@ -43,6 +44,15 @@ class StrategyParamsSpec:
     kelly_pct: Decimal
     estimated_price: Decimal
     stop_bps: Decimal
+    # `force_flatten_after` is the cutoff after which the strategy
+    # emits a SELL on any new signal if it holds inventory, regardless
+    # of `_preds`, AND blocks new BUYs. Set by the caller (sweep / run)
+    # to `window_end - kline_size` so the strategy uses its last
+    # in-window signal to close any open position. Without this,
+    # positions opened late in a window survive past `run_window`
+    # without a closing SELL — the per-day trade summary shows
+    # `trades 0` while EventSpine has BUY events without closes.
+    force_flatten_after: datetime | None = None
     # When True, ENTER actions emit LIMIT orders at the
     # estimated price (passive maker post). When False, MARKET
     # (default behavior). Plumbed via `bts run --maker` and
@@ -124,6 +134,10 @@ class ManifestBuilder:
             'estimated_price': str(strategy_params.estimated_price),
             'stop_bps': str(strategy_params.stop_bps),
             'maker_preference': bool(strategy_params.maker_preference),
+            'force_flatten_after': (
+                None if strategy_params.force_flatten_after is None
+                else strategy_params.force_flatten_after.isoformat()
+            ),
         }
         # Nexus's StrategySpec schema has no `params` field, and its
         # startup sequencer constructs `StrategyParams(raw={})` — there's

--- a/backtest_simulator/pipeline/manifest_builder.py
+++ b/backtest_simulator/pipeline/manifest_builder.py
@@ -127,6 +127,21 @@ class ManifestBuilder:
         """
         self._output_dir.mkdir(parents=True, exist_ok=True)
 
+        # `force_flatten_after` must be tz-aware. The strategy's
+        # `on_signal` compares it against `signal.timestamp`, which
+        # is UTC-aware everywhere in the runtime path (Nexus emits
+        # `datetime.now(tz=timezone.utc)`). A naive cutoff would
+        # raise `TypeError: can't compare offset-naive and offset-aware
+        # datetimes` on the first signal — fail loud at config build.
+        ffa = strategy_params.force_flatten_after
+        if ffa is not None and ffa.tzinfo is None:
+            msg = (
+                f'StrategyParamsSpec.force_flatten_after must be '
+                f'tz-aware, got naive datetime {ffa!r}. The strategy '
+                f'compares this against UTC-aware signal timestamps; '
+                f'a naive cutoff raises TypeError on the first signal.'
+            )
+            raise ValueError(msg)
         raw_params: dict[str, object] = {
             'symbol': strategy_params.symbol,
             'capital': str(strategy_params.capital),
@@ -135,8 +150,7 @@ class ManifestBuilder:
             'stop_bps': str(strategy_params.stop_bps),
             'maker_preference': bool(strategy_params.maker_preference),
             'force_flatten_after': (
-                None if strategy_params.force_flatten_after is None
-                else strategy_params.force_flatten_after.isoformat()
+                None if ffa is None else ffa.isoformat()
             ),
         }
         # Nexus's StrategySpec schema has no `params` field, and its

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "backtest_simulator"
-version = "2.2.0"
+version = "2.2.1"
 description = "Honest, gate-enforced backtester for unmodified Nexus strategies against unmodified Praxis."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,6 +202,13 @@ max-statements = 50
 # signature (it wraps SimulatedVenueAdapter.submit_order without
 # changing arity).
 "backtest_simulator/launcher/launcher.py" = ["PLR0913"]
+# `_Config.__init__` mirrors `StrategyParamsSpec`'s named fields
+# 1:1 (symbol, capital, kelly_pct, estimated_price, stop_bps,
+# force_flatten_after, maker_preference). The strategy template
+# is the bts -> Nexus boundary; bundling these into a config
+# object would lose the field clarity readers rely on when
+# auditing baked params.
+"backtest_simulator/pipeline/_strategy_templates/long_on_signal.py" = ["PLR0913"]
 # The CLI subcommand modules legitimately print() per-run summaries to
 # stdout (the operator's debug surface) and the sweep / run / pipeline
 # orchestration carries enough branches to exceed PLR0912 / PLR0915.

--- a/tests/pipeline/test_force_flatten_at_window_close.py
+++ b/tests/pipeline/test_force_flatten_at_window_close.py
@@ -18,7 +18,6 @@ from nexus.strategy.context import StrategyContext
 from nexus.strategy.params import StrategyParams
 from nexus.strategy.signal import Signal
 
-
 _T0 = datetime(2026, 4, 20, 0, 0, tzinfo=UTC)
 _KLINE_SECONDS = 14400  # 4-hour klines (matches r0011)
 _WINDOW_END = datetime(2026, 4, 20, 23, 59, 59, tzinfo=UTC)

--- a/tests/pipeline/test_force_flatten_at_window_close.py
+++ b/tests/pipeline/test_force_flatten_at_window_close.py
@@ -172,3 +172,78 @@ def test_force_flatten_disabled_when_after_is_none(tmp_path: Path) -> None:
     )
 
     assert actions == []
+
+
+def test_force_flatten_emits_sell_when_buy_fills_past_cutoff(
+    tmp_path: Path,
+) -> None:
+    """Maker BUY emitted before cutoff but filling after must trigger SELL.
+
+    Edge case Copilot flagged on PR #41: a `maker_preference=True`
+    LIMIT BUY can sit pending across the cutoff (deadline=60s). The
+    fill arrives via `on_outcome` AFTER `signal.timestamp >= cutoff`,
+    so `on_signal`'s force-flatten branch never sees it. `on_outcome`
+    must emit the closing SELL itself.
+    """
+    mod = _load_template(tmp_path, force_flatten_after=_FORCE_FLATTEN_AFTER)
+    strategy = mod.Strategy('force-flatten-fixture')
+    strategy.on_startup(StrategyParams(raw={}), _ctx())
+    pre_cutoff = _FORCE_FLATTEN_AFTER - timedelta(seconds=10)
+    enter = strategy.on_signal(
+        _signal(pre_cutoff, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+    assert len(enter) == 1
+    fill_qty = enter[0].size
+
+    past_cutoff_fill_ts = _FORCE_FLATTEN_AFTER + timedelta(seconds=5)
+    outcome = TradeOutcome(
+        outcome_id='oc-buy-late', command_id='cmd-buy-late',
+        outcome_type=TradeOutcomeType.FILLED,
+        timestamp=past_cutoff_fill_ts,
+        fill_size=fill_qty,
+        fill_price=Decimal('70000'),
+        fill_notional=fill_qty * Decimal('70000'),
+        actual_fees=Decimal('0'),
+        remaining_size=Decimal('0'),
+        reject_reason=None, cancel_reason=None,
+    )
+    actions = strategy.on_outcome(
+        outcome, StrategyParams(raw={}), _ctx(),
+    )
+
+    assert len(actions) == 1
+    assert actions[0].direction == OrderSide.SELL
+    assert actions[0].size == fill_qty
+    assert getattr(strategy, '_pending_sell') is True
+
+
+def test_force_flatten_does_not_emit_sell_when_buy_fills_before_cutoff(
+    tmp_path: Path,
+) -> None:
+    """A BUY filling before the cutoff must NOT trigger force-flatten in on_outcome."""
+    mod = _load_template(tmp_path, force_flatten_after=_FORCE_FLATTEN_AFTER)
+    strategy = mod.Strategy('force-flatten-fixture')
+    strategy.on_startup(StrategyParams(raw={}), _ctx())
+    enter = strategy.on_signal(
+        _signal(_T0, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+    fill_qty = enter[0].size
+
+    pre_cutoff_fill_ts = _FORCE_FLATTEN_AFTER - timedelta(seconds=5)
+    outcome = TradeOutcome(
+        outcome_id='oc-buy', command_id='cmd-buy',
+        outcome_type=TradeOutcomeType.FILLED,
+        timestamp=pre_cutoff_fill_ts,
+        fill_size=fill_qty,
+        fill_price=Decimal('70000'),
+        fill_notional=fill_qty * Decimal('70000'),
+        actual_fees=Decimal('0'),
+        remaining_size=Decimal('0'),
+        reject_reason=None, cancel_reason=None,
+    )
+    actions = strategy.on_outcome(
+        outcome, StrategyParams(raw={}), _ctx(),
+    )
+
+    assert actions == []
+    assert getattr(strategy, '_long') is True

--- a/tests/pipeline/test_force_flatten_at_window_close.py
+++ b/tests/pipeline/test_force_flatten_at_window_close.py
@@ -1,0 +1,175 @@
+"""long_on_signal force-flatten: at window-close cutoff, exit open inventory and refuse new BUYs."""
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.operational_mode import OperationalMode
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import (
+    TradeOutcomeType,
+)
+from nexus.strategy.action import ActionType
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.signal import Signal
+
+
+_T0 = datetime(2026, 4, 20, 0, 0, tzinfo=UTC)
+_KLINE_SECONDS = 14400  # 4-hour klines (matches r0011)
+_WINDOW_END = datetime(2026, 4, 20, 23, 59, 59, tzinfo=UTC)
+_FORCE_FLATTEN_AFTER = _WINDOW_END - timedelta(seconds=_KLINE_SECONDS)
+
+
+def _load_template(tmp_path: Path, *, force_flatten_after: datetime | None) -> object:
+    template_path = (
+        Path(__file__).resolve().parents[2]
+        / 'backtest_simulator' / 'pipeline'
+        / '_strategy_templates' / 'long_on_signal.py'
+    )
+    rendered = template_path.read_text(encoding='utf-8').replace(
+        '__BTS_PARAMS__',
+        json.dumps({
+            'symbol': 'BTCUSDT',
+            'capital': '100000',
+            'kelly_pct': '10',
+            'estimated_price': '70000',
+            'stop_bps': '50',
+            'force_flatten_after': (
+                None if force_flatten_after is None
+                else force_flatten_after.isoformat()
+            ),
+        }),
+    )
+    rendered_path = tmp_path / 'long_on_signal.py'
+    rendered_path.write_text(rendered, encoding='utf-8')
+    spec = importlib.util.spec_from_file_location(
+        f'long_on_signal_force_flatten_{tmp_path.name}', rendered_path,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ctx() -> StrategyContext:
+    return StrategyContext(
+        positions=(),
+        capital_available=Decimal('100000'),
+        operational_mode=OperationalMode.ACTIVE,
+    )
+
+
+def _signal(ts: datetime, preds: int) -> Signal:
+    return Signal(
+        predictor_fn_id='force-flatten-fixture',
+        timestamp=ts,
+        values={'_preds': preds, '_probs': 0.5},
+    )
+
+
+def _build_long_strategy(mod: object) -> object:
+    """Build a strategy and drive it into a long state via signal+outcome."""
+    strategy = mod.Strategy('force-flatten-fixture')
+    strategy.on_startup(StrategyParams(raw={}), _ctx())
+    enter = strategy.on_signal(
+        _signal(_T0, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+    assert len(enter) == 1, f'expected one BUY action, got {enter!r}'
+    fill_qty = enter[0].size
+    outcome = TradeOutcome(
+        outcome_id='oc-buy', command_id='cmd-buy',
+        outcome_type=TradeOutcomeType.FILLED,
+        timestamp=_T0 + timedelta(seconds=1),
+        fill_size=fill_qty,
+        fill_price=Decimal('70000'),
+        fill_notional=fill_qty * Decimal('70000'),
+        actual_fees=Decimal('0'),
+        remaining_size=Decimal('0'),
+        reject_reason=None, cancel_reason=None,
+    )
+    strategy.on_outcome(outcome, StrategyParams(raw={}), _ctx())
+    assert getattr(strategy, '_long') is True
+    return strategy
+
+
+def test_force_flatten_emits_sell_at_cutoff_signal_when_long(
+    tmp_path: Path,
+) -> None:
+    """A signal at force_flatten_after must emit SELL even with preds=1."""
+    mod = _load_template(tmp_path, force_flatten_after=_FORCE_FLATTEN_AFTER)
+    strategy = _build_long_strategy(mod)
+
+    actions = strategy.on_signal(
+        _signal(_FORCE_FLATTEN_AFTER, preds=1),
+        StrategyParams(raw={}), _ctx(),
+    )
+
+    assert len(actions) == 1
+    assert actions[0].action_type == ActionType.ENTER
+    assert actions[0].direction == OrderSide.SELL
+
+
+def test_force_flatten_emits_sell_after_cutoff_signal_when_long(
+    tmp_path: Path,
+) -> None:
+    """A signal past the cutoff must emit SELL when long."""
+    mod = _load_template(tmp_path, force_flatten_after=_FORCE_FLATTEN_AFTER)
+    strategy = _build_long_strategy(mod)
+
+    past_cutoff = _FORCE_FLATTEN_AFTER + timedelta(seconds=10)
+    actions = strategy.on_signal(
+        _signal(past_cutoff, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+
+    assert len(actions) == 1
+    assert actions[0].direction == OrderSide.SELL
+
+
+def test_force_flatten_blocks_new_buys_at_cutoff_when_flat(
+    tmp_path: Path,
+) -> None:
+    """preds=1 at the cutoff must NOT open a new position."""
+    mod = _load_template(tmp_path, force_flatten_after=_FORCE_FLATTEN_AFTER)
+    strategy = mod.Strategy('force-flatten-fixture')
+    strategy.on_startup(StrategyParams(raw={}), _ctx())
+    assert getattr(strategy, '_long') is False
+
+    actions = strategy.on_signal(
+        _signal(_FORCE_FLATTEN_AFTER, preds=1),
+        StrategyParams(raw={}), _ctx(),
+    )
+
+    assert actions == []
+
+
+def test_force_flatten_does_not_fire_before_cutoff_when_long(
+    tmp_path: Path,
+) -> None:
+    """A pre-cutoff preds=1 signal must NOT emit SELL when long."""
+    mod = _load_template(tmp_path, force_flatten_after=_FORCE_FLATTEN_AFTER)
+    strategy = _build_long_strategy(mod)
+
+    pre_cutoff = _FORCE_FLATTEN_AFTER - timedelta(seconds=1)
+    actions = strategy.on_signal(
+        _signal(pre_cutoff, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+
+    assert actions == []
+
+
+def test_force_flatten_disabled_when_after_is_none(tmp_path: Path) -> None:
+    """force_flatten_after=None preserves legacy behaviour (positions can orphan)."""
+    mod = _load_template(tmp_path, force_flatten_after=None)
+    strategy = _build_long_strategy(mod)
+
+    way_past = _WINDOW_END + timedelta(hours=1)
+    actions = strategy.on_signal(
+        _signal(way_past, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+
+    assert actions == []

--- a/tests/tools/test_lint_ci_contract.py
+++ b/tests/tools/test_lint_ci_contract.py
@@ -77,6 +77,14 @@ EXPECTED_RUFF_POLICY: Final[dict[str, object]] = {
         # the parity surface; collapsing them would diverge from
         # Praxis and lose per-stage knob clarity.
         'backtest_simulator/honesty/capital.py': ['PLR0913'],
+        # Slice #40: _Config.__init__ in long_on_signal.py mirrors
+        # StrategyParamsSpec's named fields 1:1 (symbol, capital,
+        # kelly_pct, estimated_price, stop_bps, force_flatten_after,
+        # maker_preference). The strategy template is the bts ->
+        # Nexus boundary; bundling these into a config object would
+        # lose the field clarity readers rely on when auditing baked
+        # params.
+        'backtest_simulator/pipeline/_strategy_templates/long_on_signal.py': ['PLR0913'],
         # M2 Task 1 (slice #17): the CLI subcommand modules
         # legitimately print() per-run summaries to stdout (the
         # operator's debug surface) and the sweep / run / pipeline


### PR DESCRIPTION
Closes #40.

## Summary

- bts strategy template now refuses to leave inventory open past the window's last in-window signal
- Mechanism is purely strategy-level: `_run_window.py` sets `StrategyParamsSpec.force_flatten_after = window_end - kline_size`; `manifest_builder` bakes it into `_BAKED_CONFIG`; `on_signal` emits SELL if long and at-or-after cutoff, refuses new BUYs at-or-after cutoff
- The forced SELL flows through the same Nexus → Praxis → venue path every other SELL takes; trade ledger / EventSpine / capital state remain naturally consistent (no bts launcher / EventSpine / tracker changes)

## Why

Per-day summary line `trades 0` was misleading on days where the strategy entered a BUY but didn't fire a closing SELL before window close — EventSpine carried the orphaned BUY events but the closed-trade ledger reported zero activity, and DSR/SPA/CPCV math consumed the biased return distribution.

## Test plan

- [x] 5 deterministic tests in `tests/pipeline/test_force_flatten_at_window_close.py` cover: SELL at cutoff signal, SELL past cutoff, BUY refused at cutoff when flat, no premature flatten before cutoff, legacy behaviour preserved when `force_flatten_after=None`
- [x] Existing `tests/pipeline/test_manifest_builder.py` + `tests/honesty/test_on_save_purity.py` (14 tests) pass — strategy template stays syntactically valid + on_save round-trips
- [ ] End-to-end sweep verification with a stateful predictor (r0011 + `predict_lookback>1`) requires the predict_lookback work on `fix/honor-bundle-data-source-params`; will land naturally once both branches merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[budget-raise: backtest_simulator/pipeline/_strategy_templates/long_on_signal.py: UTC-aware defensive check + on_outcome force-flatten branch for maker BUY fills past cutoff (slice #40)]
