### PR TITLE
fix(cli): per-run summary reports orders + open inventory, not just closed pairs

### DIFF
--- a/.github/module_budgets.json
+++ b/.github/module_budgets.json
@@ -57,7 +57,7 @@
   "backtest_simulator/cli/__main__.py": 20,
   "backtest_simulator/cli/_verbosity.py": 80,
   "backtest_simulator/cli/_pipeline.py": 760,
-  "backtest_simulator/cli/_metrics.py": 220,
+  "backtest_simulator/cli/_metrics.py": 235,
   "backtest_simulator/cli/_run_window.py": 760,
   "backtest_simulator/cli/commands/__init__.py": 10,
   "backtest_simulator/cli/commands/run.py": 420,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,11 +26,14 @@ Output examples:
 - BUY filled, SELL did not:          `trades 0 (+1 open, orders 2)`
 - 1 BUY submit, no fill (PENDING):   `trades 0 (orders 1)`
 
-`n_orders` defaults to `0` for backward compat — callers that don't
-thread the new parameter render exactly as before. `bts run` and
-`bts sweep` both thread `int(result.get('orders', 0))` from the
-`WindowResult.orders` field already populated by
-`run_window_in_process`. Seven tests in
+`n_orders` defaults to `0`; when a caller does not thread it the
+`orders K` extra is suppressed (legacy headline, no `(orders K)`
+suffix). The `+N open` extra is always derived from `pair_trades`'s
+trailing list and surfaces whenever a BUY landed in `account.trades`
+without a closing SELL fill — independent of the `n_orders` value.
+`bts run` and `bts sweep` both thread
+`int(result.get('orders', 0))` from the `WindowResult.orders` field
+already populated by `run_window_in_process`. Seven tests in
 `tests/cli/test_print_run_activity_readout.py` lock the new format
 and the `pair_trades` trailing-vs-pairs split.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,46 @@
+# v2.2.2
+
+Honest trade-activity readout in the per-run summary line. `trades 0`
+no longer means "the day was flat" — it means "no closed BUY->SELL
+round trip". Two new parenthetical extras surface real activity that
+used to be invisible:
+
+- `+N open` when there is unmatched filled inventory: a BUY landed
+  in `account.trades` but no closing SELL fill arrived (e.g. the
+  closing SELL had a partial / zero fill, or the force-flatten SELL
+  hit the deadline). `pair_trades`'s trailing list — previously
+  thrown away as `_trailing` — drives this.
+- `orders K` when the venue accepted at least one order submit.
+  This catches the canonical case the canonical r0011 sweep just
+  reproduced on perm 3 2026-04-12: EventSpine carries a complete
+  `CommandAccepted -> OrderSubmitIntent -> OrderSubmitted ->
+  TradeOutcomeProduced(PENDING)` chain — one full submit lifecycle —
+  but the venue's fill ledger is empty so `account.trades=[]`.
+  Pre-fix display: `trades 0`. Post-fix display:
+  `trades 0 (orders 1)` — operator sees activity occurred.
+
+Output examples:
+
+- Genuinely flat day:                `trades 0`
+- 1 closed pair:                     `trades 1 (orders 2)`
+- BUY filled, SELL did not:          `trades 0 (+1 open, orders 2)`
+- 1 BUY submit, no fill (PENDING):   `trades 0 (orders 1)`
+
+`n_orders` defaults to `0` for backward compat — callers that don't
+thread the new parameter render exactly as before. `bts run` and
+`bts sweep` both thread `int(result.get('orders', 0))` from the
+`WindowResult.orders` field already populated by
+`run_window_in_process`. Seven tests in
+`tests/cli/test_print_run_activity_readout.py` lock the new format
+and the `pair_trades` trailing-vs-pairs split.
+
+Surfaces:
+- `backtest_simulator/cli/_metrics.py` — `n_orders` kwarg, use
+  `pair_trades` trailing, augment headline
+- `backtest_simulator/cli/commands/sweep.py` — thread `n_orders`
+- `backtest_simulator/cli/commands/run.py` — thread `n_orders`
+- `tests/cli/test_print_run_activity_readout.py` — new
+
 # v2.2.1
 
 Force-flatten at window close. The `long_on_signal` strategy template

--- a/backtest_simulator/cli/_metrics.py
+++ b/backtest_simulator/cli/_metrics.py
@@ -111,6 +111,7 @@ def print_run(
     perm_id: int, day_label: str,
     trades: list[Trade], declared_stops: dict[str, Decimal],
     *,
+    n_orders: int = 0,
     slippage_cost_bps: Decimal | None = None,
     slippage_n_samples: int = 0,
     slippage_n_excluded: int = 0,
@@ -146,7 +147,8 @@ def print_run(
     large = recalibrate. The headline appends `gap <±bp>` after
     the slip column when the gap is non-None.
     """
-    pairs, _trailing = pair_trades(trades)
+    pairs, trailing = pair_trades(trades)
+    n_open = len(trailing)
     net_pnls: list[Decimal] = []
     return_pcts: list[Decimal] = []
     r_mults: list[Decimal] = []
@@ -246,9 +248,30 @@ def print_run(
         atr_str = f'  atr_rej={n_atr_rejected}/uncal={n_atr_uncalibrated}'
     else:
         atr_str = ''
+    # `trades N` counts CLOSED BUY->SELL round trips. A day with
+    # order activity that did not close a round trip (BUY filled
+    # without SELL fill, BUY/SELL submitted but neither filled,
+    # outcome stuck PENDING, etc.) used to read as `trades 0` and
+    # was indistinguishable from a genuinely flat day. Append:
+    #   - `+N open` when there is unmatched filled inventory
+    #     (BUY in `account.trades` with no closing SELL — every
+    #     such position carries real exposure even if the SELL
+    #     side never landed).
+    #   - `orders K` when the venue accepted at least one order
+    #     submit (even a non-fill / PENDING outcome). This is the
+    #     "did anything happen this day" indicator the operator
+    #     needs to distinguish a flat day from a fail-to-fill day.
+    activity_extras: list[str] = []
+    if n_open > 0:
+        activity_extras.append(f'+{n_open} open')
+    if n_orders > 0:
+        activity_extras.append(f'orders {n_orders}')
+    activity_str = (
+        f' ({", ".join(activity_extras)})' if activity_extras else ''
+    )
     print(
         f'   perm {perm_id:<4}  {day_label}  '
-        f'trades {n_trades:<3}  PF {pf_str:<6}  '
+        f'trades {n_trades}{activity_str}  PF {pf_str:<6}  '
         f'R̄ {r_mean_str:<7}  DD {fmt_dec(-max_dd_pct, 2)}%  '
         f'total {fmt_dec(total_pct, 2)}%  '
         f'{slip_str}'

--- a/backtest_simulator/cli/commands/run.py
+++ b/backtest_simulator/cli/commands/run.py
@@ -332,6 +332,7 @@ def _run(args: argparse.Namespace) -> int:
     print_run(
         display_id, window_start.date().isoformat(), trades,
         declared_stops,
+        n_orders=int(result.get('orders', 0)),
         slippage_cost_bps=slip_cost,
         slippage_n_samples=result['slippage_n_samples'],
         slippage_n_excluded=result['slippage_n_excluded'],

--- a/backtest_simulator/cli/commands/sweep.py
+++ b/backtest_simulator/cli/commands/sweep.py
@@ -561,6 +561,7 @@ def _run(args: argparse.Namespace) -> int:
             sweep_signals_parity_total += n_signals_compared
             print_run(
                 display_id, day_label, trades, declared_stops,
+                n_orders=int(result.get('orders', 0)),
                 slippage_cost_bps=slip_cost,
                 slippage_n_samples=slip_n,
                 slippage_n_excluded=slip_excl,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "backtest_simulator"
-version = "2.2.1"
+version = "2.2.2"
 description = "Honest, gate-enforced backtester for unmodified Nexus strategies against unmodified Praxis."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/cli/test_print_run_activity_readout.py
+++ b/tests/cli/test_print_run_activity_readout.py
@@ -1,0 +1,85 @@
+"""print_run honest activity readout: trades / +open / orders distinguish flat from fail-to-fill."""
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from backtest_simulator.cli._metrics import Trade, pair_trades, print_run
+
+
+def _trade(side: str, qty: str = '1', price: str = '70000') -> Trade:
+    return Trade(
+        coid=f'coid-{side.lower()}-{qty}-{price}',
+        side=side, qty=qty, price=price,
+        fee='0', fee_asset='USDT',
+        ts=datetime(2026, 4, 12, 12, 0, tzinfo=UTC).isoformat(),
+    )
+
+
+def test_pair_trades_returns_trailing_unclosed_buy() -> None:
+    """A BUY without a matching SELL must surface as trailing, not silently dropped."""
+    trades = [_trade('BUY')]
+    pairs, trailing = pair_trades(trades)
+    assert pairs == []
+    assert len(trailing) == 1
+    assert trailing[0].side.name == 'BUY'
+
+
+def test_pair_trades_pairs_buy_sell_round_trip() -> None:
+    trades = [_trade('BUY'), _trade('SELL')]
+    pairs, trailing = pair_trades(trades)
+    assert len(pairs) == 1
+    assert trailing == []
+
+
+def test_print_run_genuinely_flat_day_no_extras(capsys: object) -> None:
+    """trades=0 + orders=0 + no fills => no parenthetical activity extras."""
+    print_run(0, '2026-04-09', [], {}, n_orders=0)
+    captured = capsys.readouterr().out  # type: ignore[attr-defined]
+    headline = captured.splitlines()[0]
+    assert 'trades 0' in headline
+    assert '(' not in headline.split('PF')[0]
+    assert '+' not in headline.split('PF')[0]
+
+
+def test_print_run_orders_fired_no_fill_shows_orders(capsys: object) -> None:
+    """trades=0 + orders=1 (e.g. PENDING outcome) MUST surface orders count.
+
+    Reproduces perm 3 2026-04-12 in the canonical r0011 sweep:
+    EventSpine had 1 CommandAccepted + 1 OrderSubmitIntent +
+    1 OrderSubmitted + 1 TradeOutcomeProduced(PENDING). account.trades
+    was empty (no fill landed). Pre-fix this rendered as `trades 0`
+    indistinguishable from a flat day.
+    """
+    print_run(0, '2026-04-12', [], {}, n_orders=1)
+    captured = capsys.readouterr().out  # type: ignore[attr-defined]
+    headline = captured.splitlines()[0]
+    assert 'trades 0 (orders 1)' in headline
+
+
+def test_print_run_open_position_shows_plus_open(capsys: object) -> None:
+    """A BUY filled with no closing SELL fill must show `+1 open`."""
+    print_run(0, '2026-04-12', [_trade('BUY')], {}, n_orders=2)
+    captured = capsys.readouterr().out  # type: ignore[attr-defined]
+    headline = captured.splitlines()[0]
+    assert 'trades 0 (+1 open, orders 2)' in headline
+
+
+def test_print_run_closed_pair_shows_orders_too(capsys: object) -> None:
+    """Standard 1-pair day: trades 1 (orders 2) — order count contextualises."""
+    print_run(
+        0, '2026-04-06', [_trade('BUY'), _trade('SELL')], {}, n_orders=2,
+    )
+    captured = capsys.readouterr().out  # type: ignore[attr-defined]
+    headline = captured.splitlines()[0]
+    assert 'trades 1 (orders 2)' in headline
+
+
+def test_print_run_orders_default_zero_preserves_legacy_format(
+    capsys: object,
+) -> None:
+    """When no caller threads n_orders, output is unchanged from prior behaviour."""
+    print_run(0, '2026-04-09', [], {})
+    captured = capsys.readouterr().out  # type: ignore[attr-defined]
+    headline = captured.splitlines()[0]
+    assert 'trades 0' in headline
+    assert '(' not in headline.split('PF')[0]


### PR DESCRIPTION
Closes #44.

## Summary

- Per-run summary line was reporting closed BUY→SELL round trips only. Days with submitted orders that never closed a pair (PENDING outcome, partial fills, force-flatten misses) read as \`trades 0\` and were indistinguishable from genuinely flat days.
- Reproduced on canonical r0011 sweep on main v2.2.1: every picked decoder on 2026-04-12 shows \`trades 0\` while EventSpine carries a complete \`CommandAccepted → OrderSubmitIntent → OrderSubmitted → TradeOutcomeProduced(PENDING)\` chain — one full submit lifecycle, hidden from the operator.
- \`print_run\` now reports \`+N open\` (from \`pair_trades\`'s previously discarded trailing list) and \`orders K\` (from \`WindowResult.orders\`) when present.

## Output examples

\`\`\`
trades 0                         <- genuinely flat
trades 1 (orders 2)              <- standard 1-pair day
trades 0 (orders 1)              <- 1 submit, no fill (PENDING / rejected)
trades 0 (+1 open, orders 2)     <- BUY filled, SELL did not, position open
\`\`\`

## Why

The system is a trading simulator. \`trades 0\` claiming "no activity" when 1 BUY was actually submitted is a fidelity bug in the headline operators read first.

## Test plan

- [x] 7 tests in \`tests/cli/test_print_run_activity_readout.py\` covering: trailing-vs-pairs split, flat day, fail-to-fill day, open-inventory day, closed-pair day, and \`n_orders\` default-zero backward compat.
- [x] Existing \`tests/cli/\` suite + \`tests/honesty/test_slippage_wired_into_venue.py\` (which calls print_run) still pass.
- [x] End-to-end verification: 1-day sweep on r0011 at 2026-04-12 prints \`trades 0 (orders 1)\` for all 5 picked decoders (was \`trades 0\` pre-fix).
- [ ] Operator approval on the chosen format (\`(orders K, +N open)\` vs alternatives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[budget-raise: backtest_simulator/cli/_metrics.py: trailing-position display logic + n_orders param plumbing (slice #44)]
