### PR TITLE
fix(strategy): every open BUY closes before window end

### DIFF
--- a/.github/module_budgets.json
+++ b/.github/module_budgets.json
@@ -63,7 +63,7 @@
   "backtest_simulator/cli/commands/run.py": 420,
   "backtest_simulator/cli/_signals_builder.py": 500,
   "backtest_simulator/cli/_stats.py": 440,
-  "backtest_simulator/cli/commands/sweep.py": 1120,
+  "backtest_simulator/cli/commands/sweep.py": 1140,
   "backtest_simulator/cli/commands/enrich.py": 60,
   "backtest_simulator/cli/commands/test.py": 80,
   "backtest_simulator/cli/commands/lint.py": 60,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+# v2.3.1
+
+Close-by-window-end honesty invariant. Two related fixes that
+restore the operator's most basic expectation: every BUY filled
+inside a sweep window MUST be closed before the window ends —
+either by a natural `preds=0` SELL signal during the day, or by
+force-flatten at window close. Always.
+
+Strategy template: `LongOnSignal.on_signal` now runs the cutoff
+branch BEFORE the `_preds is None` early-return guard. Threshold
+models like Limen's `threshold_logreg_binary` legitimately emit
+`_preds=None` on uncertain bars (probability inside hysteresis
+band, below `min_prob_floor`). Pre-fix, if the cutoff bar happened
+to be one of those, the strategy returned `[]` immediately and
+force-flatten never fired — leaving open inventory carried past
+window close. Post-fix, the SELL fires whenever
+`signal.timestamp >= cutoff` and the strategy holds inventory,
+regardless of the predictor's abstain output.
+
+Sweep contract: `bts sweep` now aborts loud (`ParityViolation`)
+when ANY window ends with open inventory
+(`n_runs_with_trailing_inventory > 0`). The prior behaviour was
+to silently drop open-inventory days from the day-aligned subset
+fed to DSR/SPA/PBO and print the resulting numerical verdict
+without surfacing the exclusion in the headline. Stats compiled
+on the leftover subset after the strategy's most active days
+were silently excluded are not honest — refusing to ship a
+misleading verdict is the more useful answer.
+
+Static contract pinned via `tests/honesty/test_close_by_window_end.py`:
+the cutoff branch must be positioned BEFORE the `_preds is None`
+guard in source, and the sweep abort must raise `ParityViolation`
+on `n_runs_with_trailing_inventory > 0`. Future PRs that re-order
+the strategy branches or remove the sweep abort fail this gate.
+
 # v2.3.0
 
 Layer 1 honest activity readout in the per-run summary line. The

--- a/backtest_simulator/cli/commands/sweep.py
+++ b/backtest_simulator/cli/commands/sweep.py
@@ -648,6 +648,29 @@ def _run(args: argparse.Namespace) -> int:
                     )
     t_wall = time.perf_counter() - t_total
     print(f'\ndone   {total_runs} run(s) in {t_wall:.1f}s')
+    # Honesty contract: every BUY filled inside a window MUST close
+    # before the window ends. Open inventory at window close means
+    # the day's PnL is unrealized and the day gets silently dropped
+    # from DSR/SPA/PBO via `daily_return_for_run` returning None.
+    # Stats compiled on the surviving subset are not honest — they
+    # represent the leftover after the most informative days were
+    # excluded. If force-flatten failed for ANY window, the operator
+    # cannot trust the sweep result, so we abort loud rather than
+    # print a numeric verdict on a partial sample.
+    if n_runs_with_trailing_inventory > 0:
+        from backtest_simulator.exceptions import (
+            ParityViolation as _ParityViolation,
+        )
+        msg_open_inventory = (
+            f'sweep aborted: {n_runs_with_trailing_inventory} '
+            f'window(s) ended with open inventory at window close. '
+            f'Honest invariant violated: every BUY filled inside a '
+            f'window must close before the window ends (force-flatten '
+            f'or natural SELL signal). Stats computed on the '
+            f'surviving subset would silently exclude the strategy\'s '
+            f'most active days — refusing to ship a misleading verdict.'
+        )
+        raise _ParityViolation(msg_open_inventory)
     _print_sweep_slippage_summary(
         sweep_slip_costs_weighted,
         sweep_slip_gaps_weighted,

--- a/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
+++ b/backtest_simulator/pipeline/_strategy_templates/long_on_signal.py
@@ -148,6 +148,28 @@ class Strategy(_StrategyBase):
         self, signal: Signal, params: StrategyParams, context: StrategyContext,
     ) -> list[Action]:
         del params, context
+        # Force-flatten at window close runs FIRST — before the
+        # `_preds is None` guard — because the close-by-window-end
+        # invariant is non-negotiable: every BUY filled in this
+        # window MUST be closed before the window ends. Threshold
+        # models (e.g. Limen's `threshold_logreg_binary`) legitimately
+        # emit `_preds=None` on uncertain bars; if the cutoff bar
+        # happens to be one of those, the prior code returned `[]`
+        # immediately and force-flatten never fired, leaving open
+        # inventory at window close. The bts honesty contract
+        # requires the SELL to fire regardless of `_preds` value
+        # whenever `signal.timestamp >= cutoff` and the strategy
+        # holds inventory.
+        cutoff = self._config.force_flatten_after
+        at_cutoff = cutoff is not None and signal.timestamp >= cutoff
+        if at_cutoff and self._long and not self._pending_sell:
+            qty = self._entry_qty
+            self._pending_sell = True
+            _log.info(
+                'FORCE FLATTEN at window close: qty=%s ts=%s cutoff=%s',
+                qty, signal.timestamp, cutoff,
+            )
+            return [self._build_action(OrderSide.SELL, qty, signal)]
         preds_raw = signal.values.get('_preds')
         if preds_raw is None:
             _log.info('signal missing _preds; keys=%s', list(signal.values))
@@ -162,22 +184,12 @@ class Strategy(_StrategyBase):
             'on_signal fired: preds=%s probs=%s was_long=%s',
             preds, signal.values.get('_probs'), was_long,
         )
-        # Force-flatten at window close: if this signal arrives at or
-        # after the configured cutoff (window_end - kline_size), close
-        # any open position immediately and refuse new entries. The
-        # strategy's last in-window signal becomes a guaranteed
-        # exposure-zero point so per-day stats reflect realized PnL
-        # without orphaned positions.
-        cutoff = self._config.force_flatten_after
-        if cutoff is not None and signal.timestamp >= cutoff:
-            if was_long and not self._pending_sell:
-                qty = self._entry_qty
-                self._pending_sell = True
-                _log.info(
-                    'FORCE FLATTEN at window close: qty=%s ts=%s cutoff=%s',
-                    qty, signal.timestamp, cutoff,
-                )
-                return [self._build_action(OrderSide.SELL, qty, signal)]
+        # Past the cutoff but already flat or with a SELL pending: no
+        # new entries. The earlier branch already handled the
+        # `at_cutoff and _long` SELL case; this branch handles the
+        # `at_cutoff and not _long` no-op case so post-cutoff BUYs
+        # never enter the trading path.
+        if at_cutoff:
             return []
         if preds == 1 and not was_long and not self._pending_buy:
             qty_raw = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "backtest_simulator"
-version = "2.3.0"
+version = "2.3.1"
 description = "Honest, gate-enforced backtester for unmodified Nexus strategies against unmodified Praxis."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/honesty/test_close_by_window_end.py
+++ b/tests/honesty/test_close_by_window_end.py
@@ -1,0 +1,193 @@
+"""close-by-window-end honesty: every BUY filled inside a window MUST close before window ends.
+
+Three invariants pinned here:
+
+1. Force-flatten at the cutoff bar fires REGARDLESS of `_preds` value.
+   Threshold models (Limen's `threshold_logreg_binary`) legitimately
+   emit `_preds=None` on uncertain bars; if the cutoff bar is one of
+   those, the prior code returned `[]` immediately and force-flatten
+   never fired. The strategy must close held inventory whenever
+   `signal.timestamp >= cutoff`, irrespective of the predictor's
+   abstain output.
+
+2. The cutoff branch in `LongOnSignal.on_signal` is positioned
+   STRUCTURALLY BEFORE the `_preds is None` early-return guard. A
+   future PR that re-orders these branches breaks the close-by-end
+   invariant silently — this static check catches the regression at
+   the source level so it cannot ride through.
+
+3. Sweep aborts loudly when ANY window ends with open inventory.
+   Stats compiled on the leftover days after the most active days are
+   silently dropped are not honest. The sweep refuses to ship a numeric
+   verdict on a partial sample.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal
+from pathlib import Path
+
+from nexus.core.domain.enums import OrderSide
+from nexus.core.domain.operational_mode import OperationalMode
+from nexus.infrastructure.praxis_connector.trade_outcome import TradeOutcome
+from nexus.infrastructure.praxis_connector.trade_outcome_type import (
+    TradeOutcomeType,
+)
+from nexus.strategy.action import ActionType
+from nexus.strategy.context import StrategyContext
+from nexus.strategy.params import StrategyParams
+from nexus.strategy.signal import Signal
+
+_T0 = datetime(2026, 4, 20, 0, 0, tzinfo=UTC)
+_KLINE_SECONDS = 14400  # 4-hour klines (matches r0011)
+_WINDOW_END = datetime(2026, 4, 20, 23, 59, 59, tzinfo=UTC)
+_FORCE_FLATTEN_AFTER = _WINDOW_END - timedelta(seconds=_KLINE_SECONDS)
+
+
+def _load_template(tmp_path: Path) -> object:
+    template_path = (
+        Path(__file__).resolve().parents[2]
+        / 'backtest_simulator' / 'pipeline'
+        / '_strategy_templates' / 'long_on_signal.py'
+    )
+    rendered = template_path.read_text(encoding='utf-8').replace(
+        '__BTS_PARAMS__',
+        json.dumps({
+            'symbol': 'BTCUSDT',
+            'capital': '100000',
+            'kelly_pct': '10',
+            'estimated_price': '70000',
+            'stop_bps': '50',
+            'force_flatten_after': _FORCE_FLATTEN_AFTER.isoformat(),
+        }),
+    )
+    rendered_path = tmp_path / 'long_on_signal.py'
+    rendered_path.write_text(rendered, encoding='utf-8')
+    spec = importlib.util.spec_from_file_location(
+        f'long_on_signal_close_by_end_{tmp_path.name}', rendered_path,
+    )
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ctx() -> StrategyContext:
+    return StrategyContext(
+        positions=(),
+        capital_available=Decimal('100000'),
+        operational_mode=OperationalMode.ACTIVE,
+    )
+
+
+def _signal(ts: datetime, preds: int | None) -> Signal:
+    values: dict[str, object] = {'_probs': 0.5}
+    if preds is not None:
+        values['_preds'] = preds
+    return Signal(
+        predictor_fn_id='close-by-end-fixture',
+        timestamp=ts,
+        values=values,
+    )
+
+
+def _drive_into_long_state(mod: object) -> object:
+    """Open a position via preds=1 BUY signal then deliver the FILLED outcome."""
+    strategy = mod.Strategy('close-by-end-fixture')
+    strategy.on_startup(StrategyParams(raw={}), _ctx())
+    actions = strategy.on_signal(
+        _signal(_T0, preds=1), StrategyParams(raw={}), _ctx(),
+    )
+    assert len(actions) == 1
+    assert actions[0].action_type == ActionType.ENTER
+    assert actions[0].direction == OrderSide.BUY
+    fill_qty = actions[0].size
+    outcome = TradeOutcome(
+        outcome_id='oc-buy', command_id='cmd-buy',
+        outcome_type=TradeOutcomeType.FILLED,
+        timestamp=_T0 + timedelta(seconds=1),
+        fill_size=fill_qty,
+        fill_price=Decimal('70000'),
+        fill_notional=fill_qty * Decimal('70000'),
+        actual_fees=Decimal('0'),
+        remaining_size=Decimal('0'),
+        reject_reason=None, cancel_reason=None,
+    )
+    strategy.on_outcome(outcome, StrategyParams(raw={}), _ctx())
+    assert getattr(strategy, '_long') is True
+    return strategy
+
+
+def test_force_flatten_fires_when_preds_is_none(tmp_path: Path) -> None:
+    """The bug we're fixing: at the cutoff bar, _preds=None must NOT short-circuit force-flatten.
+
+    Threshold models routinely emit _preds=None on uncertain bars
+    (probability inside hysteresis band, below min_prob_floor, etc.).
+    Pre-fix, the strategy returned [] immediately on _preds=None,
+    skipping the cutoff branch entirely. A BUY filled earlier in the
+    window would carry past window close as orphaned open inventory.
+    Post-fix, the cutoff branch fires before the _preds None guard.
+    """
+    mod = _load_template(tmp_path)
+    strategy = _drive_into_long_state(mod)
+    cutoff_signal = _signal(_FORCE_FLATTEN_AFTER, preds=None)
+    actions = strategy.on_signal(
+        cutoff_signal, StrategyParams(raw={}), _ctx(),
+    )
+    assert len(actions) == 1, (
+        f'expected 1 SELL action at cutoff with _preds=None, got '
+        f'{len(actions)} actions: {actions!r}'
+    )
+    assert actions[0].action_type == ActionType.ENTER
+    assert actions[0].direction == OrderSide.SELL
+
+
+def test_force_flatten_branch_precedes_preds_none_guard() -> None:
+    """Static contract: the cutoff branch MUST be positioned before the _preds None guard.
+
+    A future PR that re-orders these branches breaks the close-by-end
+    invariant silently. Pin the source-level position so the slice's
+    capability cannot regress without this test failing first.
+    """
+    template_path = (
+        Path(__file__).resolve().parents[2]
+        / 'backtest_simulator' / 'pipeline'
+        / '_strategy_templates' / 'long_on_signal.py'
+    )
+    src = template_path.read_text(encoding='utf-8')
+    cutoff_check_pos = src.index('signal.timestamp >= cutoff')
+    preds_none_pos = src.index('preds_raw is None')
+    assert cutoff_check_pos < preds_none_pos, (
+        f'cutoff check must precede _preds None guard in '
+        f'on_signal source; got cutoff at offset '
+        f'{cutoff_check_pos} and preds_none at offset '
+        f'{preds_none_pos}'
+    )
+
+
+def test_sweep_aborts_on_open_inventory_exclusion() -> None:
+    """Static contract: sweep MUST raise ParityViolation when n_runs_with_trailing_inventory > 0.
+
+    Stats compiled on the surviving subset after the most active days
+    are silently excluded are not honest. The sweep must abort loud
+    rather than print a numeric verdict on a partial sample. This
+    test pins the abort site so a future PR cannot remove it.
+    """
+    sweep_path = (
+        Path(__file__).resolve().parents[2]
+        / 'backtest_simulator' / 'cli' / 'commands' / 'sweep.py'
+    )
+    src = sweep_path.read_text(encoding='utf-8')
+    assert 'n_runs_with_trailing_inventory > 0' in src, (
+        'sweep must check n_runs_with_trailing_inventory > 0 and abort'
+    )
+    abort_block_start = src.index('n_runs_with_trailing_inventory > 0')
+    next_section = src[abort_block_start:abort_block_start + 800]
+    assert 'ParityViolation' in next_section, (
+        'sweep abort site must raise ParityViolation, not log+continue'
+    )
+    assert 'raise' in next_section, (
+        'sweep abort site must contain a raise, not just a print'
+    )

--- a/tests/honesty/test_close_by_window_end.py
+++ b/tests/honesty/test_close_by_window_end.py
@@ -157,7 +157,16 @@ def test_force_flatten_branch_precedes_preds_none_guard() -> None:
         / '_strategy_templates' / 'long_on_signal.py'
     )
     src = template_path.read_text(encoding='utf-8')
-    cutoff_check_pos = src.index('signal.timestamp >= cutoff')
+    # zero-bang + Copilot caught this: the prior assertion used
+    # `'signal.timestamp >= cutoff'` which also appears verbatim in
+    # the file's preceding comment. `src.index()` would hit the
+    # comment first; a future PR could move the executable check
+    # below the preds-None guard while leaving the comment in
+    # place, and the test would still pass silently. Anchor the
+    # assertion on the unique executable line instead.
+    cutoff_check_pos = src.index(
+        'at_cutoff = cutoff is not None and signal.timestamp >= cutoff',
+    )
     preds_none_pos = src.index('preds_raw is None')
     assert cutoff_check_pos < preds_none_pos, (
         f'cutoff check must precede _preds None guard in '


### PR DESCRIPTION
## Summary

- Strategy template: cutoff branch in `LongOnSignal.on_signal` now runs BEFORE the `_preds is None` early-return guard so force-flatten fires regardless of the predictor's abstain output.
- Sweep contract: `bts sweep` aborts loud (`ParityViolation`) when any window ends with open inventory, instead of silently dropping the active days from DSR/SPA/PBO.
- Tests: `tests/honesty/test_close_by_window_end.py` pins both invariants (runtime + source-position).

## Closes

Closes #50

## Background

A 5×7 canonical sweep on the r0011 v3 bundle showed every active day silently excluded:
- 10 BUY fills landed (perm × {04-06, 04-08})
- 0 SELL fills ever closed them
- `n_runs_excluded_open_position=10` dropped them from stats
- DSR/SPA computed on the 25 leftover flat days

Root cause: `threshold_logreg_binary` (and other threshold models) legitimately emit `_preds=None` on uncertain bars. When the cutoff bar happened to be one of those, the strategy returned `[]` immediately and force-flatten never fired. The bts honesty contract is: every BUY filled inside a window MUST close before the window ends. Always.

## Budget raises

[budget-raise: backtest_simulator/cli/commands/sweep.py: +20 lines for the `n_runs_with_trailing_inventory > 0` ParityViolation abort + comment block explaining the honesty contract]

## Test plan

- [x] `~/.venvs/bts/bin/python -m pytest tests/honesty/test_close_by_window_end.py -v` — 3/3 pass
- [x] `~/.venvs/bts/bin/python -m pytest tests/honesty/ tests/pipeline/test_force_flatten_at_window_close.py -q` — all pass (no regression)
- [x] `~/.venvs/bts/bin/ruff check backtest_simulator tools tests` — clean
- [x] `~/.venvs/bts/bin/python tools/check_module_budgets.py` — PASS
- [x] `~/.venvs/bts/bin/python tools/fail_loud_gate.py --base-budget .github/fail_loud_budget.json` — PASS
- [x] `~/.venvs/bts/bin/python tools/version_gate.py ...` — PASS (2.3.0 → 2.3.1, fix → patch)
- [ ] Re-run 5×7 sweep on migrated v3 bundle; verify `n_runs_excluded_open_position=0` and trades > 0 per active day

🤖 Generated with [Claude Code](https://claude.com/claude-code)